### PR TITLE
Support for PHP7 return types and scalar type hints

### DIFF
--- a/src/PhpGenerator/Parameter.php
+++ b/src/PhpGenerator/Parameter.php
@@ -39,7 +39,10 @@ class Parameter extends Nette\Object
 		$param = new static;
 		$param->name = $from->getName();
 		$param->reference = $from->isPassedByReference();
-		if ($from->isArray() || $from->isCallable()) {
+		if (PHP_VERSION_ID >= 70000) {
+			$type = $from->getType();
+			$param->typeHint = !$type || $type->isBuiltin() ? (string) $type : '\\' . $type;
+		} elseif ($from->isArray() || $from->isCallable()) {
 			$param->typeHint = $from->isArray() ? 'array' : 'callable';
 		} else {
 			try {

--- a/tests/PhpGenerator/Method.returnTypes.phpt
+++ b/tests/PhpGenerator/Method.returnTypes.phpt
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Test: Nette\PhpGenerator - PHP7 return type declarations
+ * @phpversion 7.0
+ */
+
+namespace A
+{
+	class Foo {}
+}
+
+namespace
+{
+	use Nette\PhpGenerator\Method;
+	use Tester\Assert;
+
+
+	require __DIR__ . '/../bootstrap.php';
+
+	// test from
+
+	interface A
+	{
+		function testClass() : \A\Foo;
+		function testScalar() : string;
+	}
+
+	$method = Method::from(A::class .'::testClass');
+	Assert::same('\A\Foo', $method->getReturnType());
+
+	$method = Method::from(A::class .'::testScalar');
+	Assert::same('string', $method->getReturnType());
+
+	// generating methods with return type declarations
+
+	$method = (new Method)
+		->setName('create')
+		->setReturnType('Foo')
+		->setBody('return new Foo();');
+
+	Assert::match(
+		'function create(): Foo
+{
+	return new Foo();
+}
+', (string) $method);
+
+}

--- a/tests/PhpGenerator/Method.scalarParameters.phpt
+++ b/tests/PhpGenerator/Method.scalarParameters.phpt
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Test: Nette\PhpGenerator - PHP7 scalar type hints
+ * @phpversion 7.0
+ */
+
+
+use Nette\PhpGenerator\Method;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+// test from
+
+
+interface Foo
+{
+	function scalars(string $a, bool $b, int $c, float $d);
+}
+
+$method = Method::from(Foo::class . '::scalars');
+Assert::same('string', $method->getParameters()['a']->getTypeHint());
+
+$method = Method::from(Foo::class . '::scalars');
+Assert::same('bool', $method->getParameters()['b']->getTypeHint());
+
+$method = Method::from(Foo::class . '::scalars');
+Assert::same('int', $method->getParameters()['c']->getTypeHint());
+
+$method = Method::from(Foo::class . '::scalars');
+Assert::same('float', $method->getParameters()['d']->getTypeHint());
+
+
+// generating methods with scalar type hints
+
+$method = (new Method)
+	->setName('create')
+	->setBody('return null;');
+$method->addParameter('a')->setTypeHint('string');
+$method->addParameter('b')->setTypeHint('bool');
+
+Assert::match(
+'function create(string $a, bool $b)
+{
+	return null;
+}
+', (string) $method);


### PR DESCRIPTION
- feature
- documentation - not needed
- BC break - no

This PR adds support for new PHP7 language syntax & features, namely [return type declarations](https://wiki.php.net/rfc/return_types) and [scalar type hints](https://wiki.php.net/rfc/scalar_type_hints_v5) for generated files.

This feature is mandatory for PHP7 support in nette/di - ie. support of using return type declaration (instead of annotations) in automatically generated factories.
