### PR TITLE
Added missing @property for $properties

### DIFF
--- a/src/PhpGenerator/ClassType.php
+++ b/src/PhpGenerator/ClassType.php
@@ -15,6 +15,7 @@ use Nette\Utils\Strings;
  * Class/Interface/Trait description.
  *
  * @property Method[] $methods
+ * @property Property[] $properties
  */
 class ClassType
 {


### PR DESCRIPTION
This caused error with janmarek/webloader: `Missing annotation @property for Nette\PhpGenerator\ClassType::$properties used in janmarek/webloader/WebLoader/Nette/Extension.php:157`