### PR TITLE
ClassType: Added class constants

### DIFF
--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -46,6 +46,7 @@ final class Factory
 			}
 		}
 		$class->setMethods($methods);
+		$class->setConstants($from->getConstants());
 		return $class;
 	}
 

--- a/tests/PhpGenerator/ClassType.from.expect
+++ b/tests/PhpGenerator/ClassType.from.expect
@@ -64,3 +64,9 @@ class Class3
 	public $prop1;
 
 }
+
+class Class4
+{
+	const THE_CONSTANT = 9;
+
+}

--- a/tests/PhpGenerator/ClassType.from.php71.expect
+++ b/tests/PhpGenerator/ClassType.from.php71.expect
@@ -16,3 +16,10 @@ class ClassA
 	}
 
 }
+
+class ClassB
+{
+	const THE_PRIVATE_CONSTANT = 9;
+	const THE_PUBLIC_CONSTANT = 9;
+
+}

--- a/tests/PhpGenerator/ClassType.from.php71.phpt
+++ b/tests/PhpGenerator/ClassType.from.php71.phpt
@@ -23,7 +23,14 @@ class ClassA
 	function func3(): void {}
 }
 
+class ClassB
+{
+	private const THE_PRIVATE_CONSTANT = 9;
+	public const THE_PUBLIC_CONSTANT = 9;
+}
+
 
 $res[] = ClassType::from(ClassA::class);
+$res[] = ClassType::from(ClassB::class);
 
 Assert::matchFile(__DIR__ . '/ClassType.from.php71.expect', implode("\n", $res));

--- a/tests/PhpGenerator/ClassType.from.phpt
+++ b/tests/PhpGenerator/ClassType.from.phpt
@@ -69,6 +69,11 @@ class Class3
 	public $prop1;
 }
 
+class Class4
+{
+	const THE_CONSTANT = 9;
+}
+
 $res[] = ClassType::from(Interface1::class);
 $res[] = ClassType::from(Interface2::class);
 $res[] = ClassType::from(Class1::class);
@@ -76,5 +81,6 @@ $res[] = ClassType::from(new Class2);
 $obj = new Class3;
 $obj->prop2 = 1;
 $res[] = (new Factory)->fromClassReflection(new \ReflectionObject($obj));
+$res[] = ClassType::from(Class4::class);
 
 Assert::matchFile(__DIR__ . '/ClassType.from.expect', implode("\n", $res));


### PR DESCRIPTION
- bug fix? yes <!-- #issue numbers, if any -->
- new feature? no
- BC break? no

Added missing class constants when importing from ReflectionClass.
I'm not sure about that visibility in php7.1, is this ok?