### PR TITLE
Support configuring spaces between methods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.php]
+indent_style = tab
+indent_size = 4

--- a/src/PhpGenerator/ClassType.php
+++ b/src/PhpGenerator/ClassType.php
@@ -65,6 +65,7 @@ final class ClassType
 	/** @var int */
 	private $methodSpaces = 2;
 
+
 	/**
 	 * @param  string|object  $class
 	 * @return static
@@ -423,6 +424,7 @@ final class ClassType
 		return $this->methods[$name] = $method;
 	}
 
+
 	/**
 	 * Set the number of spaces used in between method declarations.
 	 *
@@ -432,6 +434,7 @@ final class ClassType
 	{
 		$this->methodSpaces = $spaces;
 	}
+
 
 	private function validate(array $names): void
 	{

--- a/src/PhpGenerator/ClassType.php
+++ b/src/PhpGenerator/ClassType.php
@@ -62,6 +62,8 @@ final class ClassType
 	/** @var Method[] name => Method */
 	private $methods = [];
 
+	/** @var int */
+	private $methodSpaces = 2;
 
 	/**
 	 * @param  string|object  $class
@@ -119,7 +121,7 @@ final class ClassType
 				($this->traits ? implode("\n", $traits) . "\n\n" : '')
 				. ($this->consts ? implode("\n", $consts) . "\n\n" : '')
 				. ($this->properties ? implode("\n\n", $properties) . "\n\n\n" : '')
-				. ($this->methods ? implode("\n\n\n", $this->methods) . "\n" : ''), 1)
+				. ($this->methods ? implode(str_repeat("\n", $this->methodSpaces + 1), $this->methods) . "\n" : ''), 1)
 			. '}'
 		) . ($this->name ? "\n" : '');
 	}
@@ -421,6 +423,15 @@ final class ClassType
 		return $this->methods[$name] = $method;
 	}
 
+	/**
+	 * Set the number of spaces used in between method declarations.
+	 *
+	 * @param int $spaces
+	 */
+	public function setMethodSpacing(int $spaces)
+	{
+		$this->methodSpaces = $spaces;
+	}
 
 	private function validate(array $names): void
 	{

--- a/tests/PhpGenerator/ClassType.methodSpaces.expect
+++ b/tests/PhpGenerator/ClassType.methodSpaces.expect
@@ -1,0 +1,10 @@
+class A
+{
+	public function foo()
+	{
+	}
+
+	public function bar()
+	{
+	}
+}

--- a/tests/PhpGenerator/ClassType.methodSpaces.phpt
+++ b/tests/PhpGenerator/ClassType.methodSpaces.phpt
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Test: Nette\PhpGenerator for configuring method spaces.
+ */
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\ClassType;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$class = new ClassType('A');
+$class->addMethod('foo');
+$class->addMethod('bar');
+$class->setMethodSpacing(1);
+
+Assert::matchFile(__DIR__ . '/ClassType.methodSpaces.expect', (string) $class);


### PR DESCRIPTION
I see that nette places [two spaces between methods](https://nette.org/en/coding-standard#toc-methods) which is fine, but doesn't match most other PHP projects. This PR makes the spacing configurable while leaving the default at 2 spaces.

- new feature
- BC break? no
- doc PR: I can write after I know this PR will be merged.