### PR TITLE
Prevent classes and methods from declared both final and abstract

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,6 @@ $class = new Nette\PhpGenerator\ClassType('Demo');
 
 $class
 	->setAbstract()
-	->setFinal()
 	->setExtends('ParentClass')
 	->addImplement('Countable')
 	->addTrait('Nette\SmartObject')
@@ -63,7 +62,7 @@ It will render this result:
  *
  * @property-read Nette\Forms\Form $form
  */
-abstract final class Demo extends ParentClass implements Countable
+abstract class Demo extends ParentClass implements Countable
 {
 	use Nette\SmartObject;
 }

--- a/src/PhpGenerator/ClassType.php
+++ b/src/PhpGenerator/ClassType.php
@@ -143,6 +143,9 @@ final class ClassType
 	 */
 	public function setFinal(bool $state = true): self
 	{
+		if ($state && $this->isAbstract()) {
+			throw new Nette\InvalidStateException('Class cannot be final and abstract.');
+		}
 		$this->final = $state;
 		return $this;
 	}
@@ -159,6 +162,9 @@ final class ClassType
 	 */
 	public function setAbstract(bool $state = true): self
 	{
+		if ($state && $this->isFinal()) {
+			throw new Nette\InvalidStateException('Class cannot be final and abstract.');
+		}
 		$this->abstract = $state;
 		return $this;
 	}

--- a/src/PhpGenerator/Method.php
+++ b/src/PhpGenerator/Method.php
@@ -100,6 +100,9 @@ final class Method
 	 */
 	public function setFinal(bool $state = true): self
 	{
+		if ($state && $this->isAbstract()) {
+			throw new Nette\InvalidStateException('Method cannot be final and abstract.');
+		}
 		$this->final = $state;
 		return $this;
 	}
@@ -116,6 +119,9 @@ final class Method
 	 */
 	public function setAbstract(bool $state = true): self
 	{
+		if ($state && $this->isFinal()) {
+			throw new Nette\InvalidStateException('Method cannot be final and abstract.');
+		}
 		$this->abstract = $state;
 		return $this;
 	}

--- a/tests/PhpGenerator/ClassType.phpt
+++ b/tests/PhpGenerator/ClassType.phpt
@@ -24,7 +24,6 @@ Assert::same([], $class->getTraitResolutions());
 
 $class
 	->setAbstract(true)
-	->setFinal(true)
 	->setExtends('ParentClass')
 	->addImplement('IExample')
 	->addImplement('IOne')
@@ -35,7 +34,7 @@ $class
 	->setConstants(['ROLE' => 'admin'])
 	->addConstant('ACTIVE', false);
 
-Assert::true($class->isFinal());
+Assert::false($class->isFinal());
 Assert::true($class->isAbstract());
 Assert::same('ParentClass', $class->getExtends());
 Assert::same(['ObjectTrait', 'AnotherTrait'], $class->getTraits());
@@ -147,3 +146,14 @@ $class->addMethod('b');
 $class->removeMethod('b')->removeMethod('c');
 
 Assert::same(['a'], array_keys($class->getMethods()));
+
+// class cannot be final and abstract
+Assert::exception(function () {
+	$class = new ClassType;
+	$class->setFinal(true)->setAbstract(true);
+}, Nette\InvalidStateException::class, 'Class cannot be final and abstract.');
+
+Assert::exception(function () {
+	$class = new ClassType;
+	$class->setAbstract(true)->setFinal(true);
+}, Nette\InvalidStateException::class, 'Class cannot be final and abstract.');

--- a/tests/PhpGenerator/Method.finalabstract.phpt
+++ b/tests/PhpGenerator/Method.finalabstract.phpt
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Test: Nette\PhpGenerator & variadics.
+ */
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\Method;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::exception(function () {
+	$method = new Method('foo');
+	$method->setFinal(true)->setAbstract(true);
+}, Nette\InvalidStateException::class, 'Method cannot be final and abstract.');
+
+Assert::exception(function () {
+	$method = new Method('foo');
+	$method->setAbstract(true)->setFinal(true);
+}, Nette\InvalidStateException::class, 'Method cannot be final and abstract.');

--- a/tests/PhpGenerator/Printer.namespace.phpt
+++ b/tests/PhpGenerator/Printer.namespace.phpt
@@ -17,7 +17,6 @@ $namespace->addUse('Bar\C');
 
 $class = $namespace->addClass('A')
 	->setAbstract(true)
-	->setFinal(true)
 	->setExtends('ParentClass')
 	->addImplement('IExample')
 	->addImplement('Foo\IOne')

--- a/tests/PhpGenerator/Printer.phpt
+++ b/tests/PhpGenerator/Printer.phpt
@@ -16,7 +16,6 @@ $printer = new Printer;
 
 $class = (new ClassType('Example'))
 	->setAbstract(true)
-	->setFinal(true)
 	->setExtends('ParentClass')
 	->addImplement('IExample')
 	->setTraits(['ObjectTrait'])

--- a/tests/PhpGenerator/PsrPrinter.phpt
+++ b/tests/PhpGenerator/PsrPrinter.phpt
@@ -16,7 +16,6 @@ $printer = new PsrPrinter;
 
 $class = (new ClassType('Example'))
 	->setAbstract(true)
-	->setFinal(true)
 	->setExtends('ParentClass')
 	->addImplement('IExample')
 	->setTraits(['ObjectTrait'])

--- a/tests/PhpGenerator/expected/ClassType.expect
+++ b/tests/PhpGenerator/expected/ClassType.expect
@@ -4,7 +4,7 @@
  *
  * @property-read Nette\Forms\Form $form
  */
-abstract final class Example extends ParentClass implements IExample, IOne
+abstract class Example extends ParentClass implements IExample, IOne
 {
 	use ObjectTrait;
 	use AnotherTrait {

--- a/tests/PhpGenerator/expected/Printer.class.expect
+++ b/tests/PhpGenerator/expected/Printer.class.expect
@@ -2,7 +2,7 @@
  * Description of class.
  * This is example
  */
-abstract final class Example extends ParentClass implements IExample
+abstract class Example extends ParentClass implements IExample
 {
 	use ObjectTrait;
 	use AnotherTrait {

--- a/tests/PhpGenerator/expected/Printer.namespace.class.expect
+++ b/tests/PhpGenerator/expected/Printer.namespace.class.expect
@@ -2,7 +2,7 @@
  * Description of class.
  * This is example
  */
-abstract final class A extends \ParentClass implements \IExample, IOne
+abstract class A extends \ParentClass implements \IExample, IOne
 {
 	use ObjectTrait;
 

--- a/tests/PhpGenerator/expected/Printer.namespace.class2.expect
+++ b/tests/PhpGenerator/expected/Printer.namespace.class2.expect
@@ -2,7 +2,7 @@
  * Description of class.
  * This is example
  */
-abstract final class A extends ParentClass implements IExample, Foo\IOne
+abstract class A extends ParentClass implements IExample, Foo\IOne
 {
 	use Foo\ObjectTrait;
 

--- a/tests/PhpGenerator/expected/Printer.namespace.expect
+++ b/tests/PhpGenerator/expected/Printer.namespace.expect
@@ -6,7 +6,7 @@ use Bar\C;
  * Description of class.
  * This is example
  */
-abstract final class A extends \ParentClass implements \IExample, IOne
+abstract class A extends \ParentClass implements \IExample, IOne
 {
 	use ObjectTrait;
 

--- a/tests/PhpGenerator/expected/PsrPrinter.class.expect
+++ b/tests/PhpGenerator/expected/PsrPrinter.class.expect
@@ -2,7 +2,7 @@
  * Description of class.
  * This is example
  */
-abstract final class Example extends ParentClass implements IExample
+abstract class Example extends ParentClass implements IExample
 {
     use ObjectTrait;
     use AnotherTrait {


### PR DESCRIPTION
- bug fix? Yes
- BC break? yes
- doc PR: N/A

Classes and methods cannot be declared final and abstract. This will now throw an exception if you try to generate a final abstract class or method. It's a BC break because of the new exception, but the generated code would never have been valid, so I doubt there is any use that will break
