### PR TITLE
Factory: fix method bodies import [Closes #61]

### DIFF
--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -225,6 +225,7 @@ final class Factory
 		return Helpers::indentPhp($body, -1);
 	}
 
+
 	/**
 	 * @param PhpParser\NodeFinder $nodeFinder
 	 * @param string $originalCode
@@ -267,6 +268,7 @@ final class Factory
 		}
 		return $body;
 	}
+
 
 	private function parse($from): array
 	{

--- a/tests/PhpGenerator/GlobalFunction.phpt
+++ b/tests/PhpGenerator/GlobalFunction.phpt
@@ -11,7 +11,7 @@ require __DIR__ . '/../bootstrap.php';
 /** global */
 function func(stdClass $a, $b = null)
 {
-	echo 'hello';
+	echo sprintf('hello, %s', 'world');
 	return 1;
 }
 
@@ -34,7 +34,7 @@ same(
  */
 function func(stdClass $a, $b = null)
 {
-	echo \'hello\';
+	echo \\sprintf(\'hello, %s\', \'world\');
 	return 1;
 }
 ', (string) $function);

--- a/tests/PhpGenerator/expected/ClassType.from.bodies.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.bodies.expect
@@ -27,13 +27,13 @@ abstract class Class7
 
 	public function long()
 	{
-		if ($member instanceof Method) {
+		if ($member instanceof \Abc\Method) {
 			$s = [1, 2, 3];
 		}
 		/*
 		$this->methods[$member->getName()] = $member;
 		*/
-		throw new Nette\InvalidArgumentException('Argument must be Method|Property|Constant.');
+		throw new \Nette\InvalidArgumentException('Argument must be Method|Property|Constant.');
 	}
 
 
@@ -56,8 +56,8 @@ abstract class Class7
 		/** multi
 		line
 		comment */
-
-		if ($member instanceof Method) {
+		// Alias Method will not be resolved in comment
+		if ($member instanceof \Abc\Method) {
 			$s1 = '
 a
 	b
@@ -87,6 +87,6 @@ a
 		c
 			<?php
 		}
-		throw new Nette\InvalidArgumentException();
+		throw new \Nette\InvalidArgumentException();
 	}
 }

--- a/tests/PhpGenerator/fixtures/class-body.phpf
+++ b/tests/PhpGenerator/fixtures/class-body.phpf
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Abc;
 
+use Nette;
+
 abstract class Class7
 {
 	abstract function abstractFun();
@@ -51,7 +53,7 @@ abstract class Class7
 		/** multi
 		line
 		comment */
-
+		// Alias Method will not be resolved in comment
 		if ($member instanceof Method) {
 			$s1 = '
 a


### PR DESCRIPTION
- bug fix? yes [Closes #61]
- BC break? no

fix method bodies import: 
We collect all Name Nodes from $method->stmts, their resolved FQN and position in file.
Then we replace them in body string by positions with offset correction (because we change string length)
Test cases was changed too.