### PR TITLE
Enable php syntax highlighting for non standard extension php files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 .travis.yml export-ignore
 tests/ export-ignore
 *.sh eol=lf
+
+*.phpf  linguist-language=PHP
+*.php74  linguist-language=PHP


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: nette/docs: no

In this repository are php files with non-standard php extension, so Github UI cannot highlight them with php syntax highlighter. With this change Github UI is able to highlight them.
Some short info about this: https://github.com/github/linguist#using-gitattributes
