### PR TITLE
Feature: add PhpNamespace to PhpFile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -504,6 +504,10 @@ $file->setStrictTypes(); // adds declare(strict_types=1)
 $namespace = $file->addNamespace('Foo');
 $class = $namespace->addClass('A');
 $class->addMethod('hello');
+// or
+$namespace = new Nette\PhpGenerator\PhpNamespace('Foo');
+$namespace->addClass('A')->addMethod('hello');
+$file->add($namespace);
 
 echo $file;
 

--- a/src/PhpGenerator/PhpFile.php
+++ b/src/PhpGenerator/PhpFile.php
@@ -11,7 +11,6 @@ namespace Nette\PhpGenerator;
 
 use Nette;
 
-
 /**
  * Instance of PHP file.
  *
@@ -59,12 +58,25 @@ final class PhpFile
 	public function addNamespace(string $name): PhpNamespace
 	{
 		if (!isset($this->namespaces[$name])) {
-			$this->namespaces[$name] = new PhpNamespace($name);
+			$this->add(new PhpNamespace($name));
+		}
+
+		return $this->namespaces[$name];
+	}
+
+
+	/** @return static */
+	public function add(PhpNamespace $namespace): self
+	{
+		$name = $namespace->getName();
+		if (!isset($this->namespaces[$name])) {
+			$this->namespaces[$name] = $namespace;
 			foreach ($this->namespaces as $namespace) {
 				$namespace->setBracketedSyntax(count($this->namespaces) > 1 && isset($this->namespaces['']));
 			}
 		}
-		return $this->namespaces[$name];
+
+		return $this;
 	}
 
 

--- a/tests/PhpGenerator/PhpFile.add.phpt
+++ b/tests/PhpGenerator/PhpFile.add.phpt
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpFile;
+use Nette\PhpGenerator\PhpNamespace;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::exception(function () {
+	(new PhpFile)->add((new PhpNamespace('Foo'))->add(new ClassType));
+}, Nette\InvalidArgumentException::class, 'Class does not have a name.');
+
+
+$phpFile = (new PhpFile)->add(($namespace = new PhpNamespace('FooBar'))
+	->add(($classA = new ClassType('Foo'))->addMethod('baz')->setReturnType('FooBar\\Bar')->setBody('return new Bar();') ? $classA : $classA)
+	->add(new ClassType('Bar'))
+	);
+
+
+same('<?php
+
+namespace FooBar;
+
+class Foo
+{
+	public function baz(): Bar
+	{
+		return new Bar();
+	}
+}
+
+class Bar
+{
+}
+', (string) $phpFile);
+
+Assert::null($classA->getNamespace());
+Assert::null($classA->getNamespace());


### PR DESCRIPTION
### Description

Add `PhpNamespace` classes to a `PhpFile` class.


- **bug fix?** `no`
- **new feature?** `yes`
- **BC break?** `no`



### Example

```php
<?php declare(strict_types=1); 

use Nette\PhpGenerator\ClassType;
use Nette\PhpGenerator\PhpFile;
use Nette\PhpGenerator\PhpNamespace;

$phpFile= new PhpFile();
$namespace = new PhpNamespace('FooBar');
$class = new ClassType('Foo');

$method = $class->addMethod('baz');
$method->setReturnType('FooBar\\Bar');
$method->setBody('return new Bar();');

$namespace->add($class);
$namespace->add(new ClassType('Bar'));

$phpFile->add($namespace);

echo $phpFile;
```
### Result:
```php
<?php

namespace FooBar;

class Foo
{
    public function baz(): Bar
    {
        return new Bar();
    }
}

class Bar
{
}
```

closes #67