### PR TITLE
Toggle for resolving of class names when using withBodyFrom functionality

### DIFF
--- a/src/PhpGenerator/ClassType.php
+++ b/src/PhpGenerator/ClassType.php
@@ -80,9 +80,9 @@ final class ClassType
 	/**
 	 * @param  string|object  $class
 	 */
-	public static function withBodiesFrom($class): self
+	public static function withBodiesFrom($class, bool $resolveClassNames = true): self
 	{
-		return (new Factory)->fromClassReflection(new \ReflectionClass($class), true);
+		return (new Factory)->fromClassReflection(new \ReflectionClass($class), true, $resolveClassNames);
 	}
 
 

--- a/src/PhpGenerator/GlobalFunction.php
+++ b/src/PhpGenerator/GlobalFunction.php
@@ -31,9 +31,9 @@ final class GlobalFunction
 	}
 
 
-	public static function withBodyFrom(string $function): self
+	public static function withBodyFrom(string $function, bool $resolveClassNames = true): self
 	{
-		return (new Factory)->fromFunctionReflection(new \ReflectionFunction($function), true);
+		return (new Factory)->fromFunctionReflection(new \ReflectionFunction($function), true, $resolveClassNames);
 	}
 
 


### PR DESCRIPTION
- bug fix / new feature?  **feature**
- BC break? **no**

In order to create a class from an existing file and move it to another location with another namespace, it was necessary to be able to disable the replacing of class names in function bodies with fully qualified versions, and rather relying on correct use statements.

Also made the change in the most harmless way so nothing breaks :crossed_fingers: 

Hope this is a valuable addition :) 
