### PR TITLE
Do not prescribe numeric array indices in setParameters

### DIFF
--- a/src/PhpGenerator/Traits/FunctionLike.php
+++ b/src/PhpGenerator/Traits/FunctionLike.php
@@ -69,9 +69,11 @@ trait FunctionLike
 	 */
 	public function setParameters(array $val): self
 	{
-		(function (Parameter ...$val) {})(...$val);
 		$this->parameters = [];
 		foreach ($val as $v) {
+			if (!$v instanceof Parameter) {
+				throw new Nette\InvalidArgumentException('Argument must be Nette\PhpGenerator\Parameter[].');
+			}
 			$this->parameters[$v->getName()] = $v;
 		}
 		return $this;


### PR DESCRIPTION
The following code broke:

```php
        $parameters = $execute->getParameters();
        $parameters[] = $parameter;

        $execute->setParameters($parameters);
```

```
Error: Cannot unpack array with string keys

/home/benedikt/projects/sailor/vendor/nette/php-generator/src/PhpGenerator/Traits/FunctionLike.php:72
```

- bug fix
- BC break? no
- doc PR: just a fix for breakage
