### PR TITLE
Fix trailing whitespace in multiline doc comments

### DIFF
--- a/src/PhpGenerator/Helpers.php
+++ b/src/PhpGenerator/Helpers.php
@@ -84,7 +84,7 @@ final class Helpers
 		if ($s === '') {
 			return '';
 		} elseif (str_contains($content, "\n")) {
-			return str_replace("\n", "\n * ", "/**\n$s") . "\n */\n";
+			return str_replace("\n", "\n *", "/**\n$s") . "\n */\n";
 		} else {
 			return "/** $s */\n";
 		}


### PR DESCRIPTION
- bug fix
- BC break? no

Fix trailing whitespace in multiline doc comments