### PR TITLE
Readonly keyword support for promoted parameters when loading from existing code

### DIFF
--- a/src/PhpGenerator/Extractor.php
+++ b/src/PhpGenerator/Extractor.php
@@ -391,8 +391,9 @@ final class Extractor
 		$function->setReturnType($node->getReturnType() ? $this->toPhp($node->getReturnType()) : null);
 		foreach ($node->getParams() as $item) {
 			$visibility = $this->toVisibility($item->flags);
+			$isReadonly = $this->toReadonly($item->flags);
 			$param = $visibility
-				? ($function->addPromotedParameter($item->var->name))->setVisibility($visibility)
+				? ($function->addPromotedParameter($item->var->name))->setVisibility($visibility)->setReadonly($isReadonly)
 				: $function->addParameter($item->var->name);
 			$param->setType($item->type ? $this->toPhp($item->type) : null);
 			$param->setReference($item->byRef);
@@ -419,6 +420,11 @@ final class Extractor
 			(bool) ($flags & Node\Stmt\Class_::MODIFIER_PRIVATE) => ClassType::VisibilityPrivate,
 			default => null,
 		};
+	}
+
+
+	private function toReadonly(int $flags): bool {
+		return (bool) ($flags & Node\Stmt\Class_::MODIFIER_READONLY);
 	}
 
 

--- a/tests/PhpGenerator/expected/Extractor.classes.expect
+++ b/tests/PhpGenerator/expected/Extractor.classes.expect
@@ -162,3 +162,10 @@ class Class10
 	{
 	}
 }
+
+class Class11
+{
+	public function __construct(private readonly string $foo)
+	{
+	}
+}

--- a/tests/PhpGenerator/fixtures/classes.php
+++ b/tests/PhpGenerator/fixtures/classes.php
@@ -174,3 +174,12 @@ class Class10
 	{
 	}
 }
+
+class Class11
+{
+	public function __construct(
+		private readonly string $foo
+	)
+	{
+	}
+}

--- a/tests/PhpGenerator/fixtures/classes.php
+++ b/tests/PhpGenerator/fixtures/classes.php
@@ -177,9 +177,11 @@ class Class10
 
 class Class11
 {
-	public function __construct(
-		private readonly string $foo
-	)
+	private readonly string $bar;
+
+
+	public function __construct(private readonly string $foo)
 	{
+		$this->bar = "foobar";
 	}
 }


### PR DESCRIPTION
- bug fix issue #110
- BC break? no

This PR makes the `readonly` keyword to be supported in promoted parameters by the extractor.

Tests have been updated in order to reflect that this fix works.