### PR TITLE
Fix PSR namespaces

### DIFF
--- a/src/PhpGenerator/PhpNamespace.php
+++ b/src/PhpGenerator/PhpNamespace.php
@@ -160,9 +160,9 @@ final class PhpNamespace
 
 
 	/** @return string[] */
-	public function getUses(string $of = self::NameNormal): array
+	public function getUses(string $of = self::NameNormal, bool $psrSort = false): array
 	{
-		asort($this->aliases[$of]);
+		$psrSort ? uasort($this->aliases[$of], fn (string $first, string $second): int => strcasecmp(str_replace('\\', ' ', $first), str_replace('\\', ' ', $second))) : asort($this->aliases[$of]);
 		return array_filter(
 			$this->aliases[$of],
 			fn($name, $alias) => strcasecmp(($this->name ? $this->name . '\\' : '') . $alias, $name),

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -24,6 +24,8 @@ class Printer
 	public string $indentation = "\t";
 	public int $linesBetweenProperties = 0;
 	public int $linesBetweenMethods = 2;
+    public int $linesBetweenNamespaceTypes = 0;
+    public bool $psrSortNamespaces = false;
 	public string $returnTypeColon = ': ';
 	public bool $bracesOnNextLine = true;
 	protected ?PhpNamespace $namespace = null;
@@ -256,7 +258,9 @@ class Printer
 		$this->namespace = $this->resolveTypes ? $namespace : null;
 		$name = $namespace->getName();
 		$uses = $this->printUses($namespace)
+			. str_repeat("\n", $this->linesBetweenNamespaceTypes)
 			. $this->printUses($namespace, PhpNamespace::NameFunction)
+			. str_repeat("\n", $this->linesBetweenNamespaceTypes)
 			. $this->printUses($namespace, PhpNamespace::NameConstant);
 
 		$items = [];
@@ -305,9 +309,8 @@ class Printer
 			PhpNamespace::NameFunction => 'function ',
 			PhpNamespace::NameConstant => 'const ',
 		][$of];
-		$name = $namespace->getName();
 		$uses = [];
-		foreach ($namespace->getUses($of) as $alias => $original) {
+		foreach ($namespace->getUses($of, $this->psrSortNamespaces) as $alias => $original) {
 			$uses[] = Helpers::extractShortName($original) === $alias
 				? "use $prefix$original;\n"
 				: "use $prefix$original as $alias;\n";

--- a/src/PhpGenerator/PsrPrinter.php
+++ b/src/PhpGenerator/PsrPrinter.php
@@ -18,5 +18,5 @@ final class PsrPrinter extends Printer
 	public string $indentation = '    ';
 	public int $linesBetweenMethods = 1;
 	public int $linesBetweenNamespaceTypes = 1;
-    public bool $psrSortNamespaces = true;
+	public bool $psrSortNamespaces = true;
 }

--- a/src/PhpGenerator/PsrPrinter.php
+++ b/src/PhpGenerator/PsrPrinter.php
@@ -17,4 +17,6 @@ final class PsrPrinter extends Printer
 {
 	public string $indentation = '    ';
 	public int $linesBetweenMethods = 1;
+	public int $linesBetweenNamespaceTypes = 1;
+    public bool $psrSortNamespaces = true;
 }


### PR DESCRIPTION
- Bugfix
- BC: There is a difference in the output of `PsrPrinter`

The PSR standard(s) seem to indicate that they use a newline between use statements of different types (class, function and const). 
It would be nice if this could be supported
