### PR TITLE
Ensure that object class contains path from root namespace

### DIFF
--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -272,7 +272,7 @@ final class Factory
 
 	public function fromObject(object $obj): Literal
 	{
-		return new Literal('new ' . $obj::class . '(/* unknown */)');
+		return new Literal('new \\' . $obj::class . '(/* unknown */)');
 	}
 
 

--- a/tests/PhpGenerator/ClassType.from.phpt
+++ b/tests/PhpGenerator/ClassType.from.phpt
@@ -29,5 +29,6 @@ $res[] = ClassType::from(Abc\Class7::class);
 $res[] = ClassType::from(Abc\Class8::class);
 $res[] = ClassType::from(Abc\Class9::class);
 $res[] = ClassType::from(Abc\Class10::class);
+$res[] = ClassType::from(Abc\Class11::class);
 
 sameFile(__DIR__ . '/expected/ClassType.from.expect', implode("\n", $res));

--- a/tests/PhpGenerator/expected/ClassType.from.81.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.81.expect
@@ -1,4 +1,4 @@
-#[Attr(new Abc\Attr(/* unknown */))]
+#[Attr(new \Abc\Attr(/* unknown */))]
 class Class11
 {
 	final public const FOO = 10;
@@ -12,7 +12,7 @@ class Class11
 	}
 
 
-	public function bar($c = new stdClass(/* unknown */))
+	public function bar($c = new \stdClass(/* unknown */))
 	{
 	}
 }

--- a/tests/PhpGenerator/expected/ClassType.from.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.expect
@@ -152,3 +152,15 @@ class Class10
 	{
 	}
 }
+
+class Class11
+{
+	public string|int $prop;
+
+
+	public function test(
+		Class2 $param = new \Abc\Class2(/* unknown */),
+		Class3 $param2 = new \Abc\Class3(/* unknown */),
+	): string|int {
+	}
+}

--- a/tests/PhpGenerator/expected/Extractor.classes.expect
+++ b/tests/PhpGenerator/expected/Extractor.classes.expect
@@ -162,3 +162,13 @@ class Class10
 	{
 	}
 }
+
+class Class11
+{
+	public string|int $prop;
+
+
+	function test(Class2 $param = new Class2(), Class3 $param2 = new Class3()): string|int
+	{
+	}
+}

--- a/tests/PhpGenerator/fixtures/classes.php
+++ b/tests/PhpGenerator/fixtures/classes.php
@@ -174,3 +174,12 @@ class Class10
 	{
 	}
 }
+
+class Class11
+{
+    public string|int $prop;
+
+    function test(Class2 $param = new Class2(), \Abc\Class3 $param2 = new \Abc\Class3()): string|int
+    {
+    }
+}


### PR DESCRIPTION
- bug fix 
- BC break? no

Hi,

at first thank you for the package.

I've found that created objects in default parameters in methods does not contain valid class path (it should be from a root, currently uses namespace of the file which is incorrect).

This PR ensures that the object class always uses root path namespace.

Here is current "broken" expectation in my test:

- [test result](https://github.com/wrk-flow/larastrict/actions/runs/3097068164/jobs/5013334727)
-  [implementation](https://github.com/wrk-flow/larastrict/blob/5bf5ef1bed27919bb9342723d1ab24e2b56339ae/src/Testing/Commands/MakeExpectationCommand.php#L125)
-  [expected file result](https://github.com/wrk-flow/larastrict/blob/5bf5ef1bed27919bb9342723d1ab24e2b56339ae/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractAssert.php.stub)

I'm using `$assertMethod = (new Factory())->fromMethodReflection($method);`


Also I've noticed a deprecated usage of (string) reflectionType (it is deprecated since 7.1). I'm currently implemented possible alternative (should cover everything I've found):
- [implementation](https://github.com/wrk-flow/larastrict/blob/5bf5ef1bed27919bb9342723d1ab24e2b56339ae/src/Testing/Commands/MakeExpectationCommand.php#L288)
- All possible variants I've found are defined [here](https://github.com/wrk-flow/larastrict/blob/5bf5ef1bed27919bb9342723d1ab24e2b56339ae/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContract.php).

If you are interested I can contribute it to the factory (so a I can later us it?).

Have a great day,


