### PR TITLE
Fix namespace sorting of capitalcase

### DIFF
--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -7,7 +7,7 @@ jobs:
         name: Nette Code Checker
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0
@@ -21,7 +21,7 @@ jobs:
         name: Nette Coding Standard
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0

--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: shivammathur/setup-php@v1
+            - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0
                   coverage: none
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: shivammathur/setup-php@v1
+            - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0
                   coverage: none

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,7 @@ jobs:
         name: PHPStan
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
         name: PHP ${{ matrix.php }} tests
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
@@ -22,7 +22,7 @@ jobs:
             - run: composer install --no-progress --prefer-dist
             - run: vendor/bin/tester tests -s -C
             - if: failure()
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: output
                   path: tests/**/output
@@ -32,7 +32,7 @@ jobs:
         name: Lowest Dependencies
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0
@@ -46,7 +46,7 @@ jobs:
         name: Code Coverage
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 8.0

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "nette/php-generator",
-	"description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 8.1 features.",
+	"description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 8.2 features.",
 	"keywords": ["nette", "php", "code", "scaffolding"],
 	"homepage": "https://nette.org",
 	"license": ["BSD-3-Clause", "GPL-2.0-only", "GPL-3.0-only"],
@@ -20,7 +20,7 @@
 	},
 	"require-dev": {
 		"nette/tester": "^2.4",
-		"nikic/php-parser": "^4.13",
+		"nikic/php-parser": "^4.14",
 		"tracy/tracy": "^2.8",
 		"phpstan/phpstan": "^1.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	},
 	"require-dev": {
 		"nette/tester": "^2.4",
-		"nikic/php-parser": "^4.14",
+		"nikic/php-parser": "^4.15",
 		"tracy/tracy": "^2.8",
 		"phpstan/phpstan": "^1.0"
 	},

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Match expression does not handle remaining value\: true$#'
-			count: 1
-			path: src/PhpGenerator/ClassLike.php
-
-		-
 			message: '#^Method Nette\\PhpGenerator\\ClassType\:\:addTrait\(\) has parameter \$deprecatedParam with no value type specified in iterable type array\.$#'
 			count: 1
 			path: src/PhpGenerator/ClassType.php
@@ -14,16 +9,6 @@ parameters:
 			message: '#^Method Nette\\PhpGenerator\\EnumType\:\:addTrait\(\) has parameter \$deprecatedParam with no value type specified in iterable type array\.$#'
 			count: 1
 			path: src/PhpGenerator/EnumType.php
-
-		-
-			message: '#^Access to an undefined property PhpParser\\Node\:\:\$attrGroups\.$#'
-			count: 1
-			path: src/PhpGenerator/Extractor.php
-
-		-
-			message: '#^Access to an undefined property PhpParser\\Node\\Expr\:\:\$value\.$#'
-			count: 1
-			path: src/PhpGenerator/Extractor.php
 
 		-
 			message: '#^Call to an undefined method Nette\\PhpGenerator\\ClassLike\:\:addConstant\(\)\.$#'
@@ -46,12 +31,17 @@ parameters:
 			path: src/PhpGenerator/Extractor.php
 
 		-
+			message: '#^Call to an undefined method Nette\\PhpGenerator\\FunctionLike\:\:addPromotedParameter\(\)\.$#'
+			count: 1
+			path: src/PhpGenerator/Extractor.php
+
+		-
 			message: '#^Method Nette\\PhpGenerator\\Extractor\:\:addCommentAndAttributes\(\) has parameter \$element with no type specified\.$#'
 			count: 1
 			path: src/PhpGenerator/Extractor.php
 
 		-
-			message: '#^Property class@anonymous/PhpGenerator/Extractor\.php\:176\:\:\$callback has no type specified\.$#'
+			message: '#^Property class@anonymous/PhpGenerator/Extractor\.php\:175\:\:\$callback has no type specified\.$#'
 			count: 1
 			path: src/PhpGenerator/Extractor.php
 
@@ -62,6 +52,11 @@ parameters:
 
 		-
 			message: '#^Call to an undefined method ReflectionClass\<object\>\:\:hasCase\(\)\.$#'
+			count: 1
+			path: src/PhpGenerator/Factory.php
+
+		-
+			message: '#^Call to an undefined method ReflectionClass\<object\>\:\:isReadOnly\(\)\.$#'
 			count: 1
 			path: src/PhpGenerator/Factory.php
 
@@ -91,11 +86,6 @@ parameters:
 			path: src/PhpGenerator/Factory.php
 
 		-
-			message: '#^Parameter \#1 \$name of method Nette\\PhpGenerator\\ClassType\:\:setExtends\(\) expects string\|null, array\<int, string\> given\.$#'
-			count: 1
-			path: src/PhpGenerator/Factory.php
-
-		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			count: 1
 			path: src/PhpGenerator/Factory.php
@@ -114,6 +104,11 @@ parameters:
 			message: '#^Method Nette\\PhpGenerator\\Method\:\:from\(\) has parameter \$method with no value type specified in iterable type array\.$#'
 			count: 1
 			path: src/PhpGenerator/Method.php
+
+		-
+			message: '#^Method Nette\\PhpGenerator\\Printer\:\:printDocComment\(\) has parameter \$commentable with no type specified\.$#'
+			count: 1
+			path: src/PhpGenerator/Printer.php
 
 		-
 			message: '#^Method Nette\\PhpGenerator\\TraitType\:\:addTrait\(\) has parameter \$deprecatedParam with no value type specified in iterable type array\.$#'

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ public function __construct(
 }
 ```
 
-Readonly properties introduced by PHP 8.1 can be marked via `setReadOnly()`.
+Readonly properties and classes can be marked via `setReadOnly()`.
 
 ------
 

--- a/readme.md
+++ b/readme.md
@@ -502,7 +502,7 @@ Each type or union/intersection type can be passed as a string, you can also use
 ```php
 use Nette\PhpGenerator\Type;
 
-$member->setType('array'); // or Type::ARRAY;
+$member->setType('array'); // or Type::Array;
 $member->setType('array|string'); // or Type::union('array', 'string')
 $member->setType('Foo&Bar'); // or Type::intersection(Foo::class, Bar::class)
 $member->setType(null); // removes type

--- a/src/PhpGenerator/ClassType.php
+++ b/src/PhpGenerator/ClassType.php
@@ -36,6 +36,7 @@ final class ClassType extends ClassLike
 	private bool $final = false;
 	private bool $abstract = false;
 	private ?string $extends = null;
+	private bool $readOnly = false;
 
 	/** @var string[] */
 	private array $implements = [];
@@ -169,6 +170,19 @@ final class ClassType extends ClassLike
 	public function isAbstract(): bool
 	{
 		return $this->abstract;
+	}
+
+
+	public function setReadOnly(bool $state = true): static
+	{
+		$this->readOnly = $state;
+		return $this;
+	}
+
+
+	public function isReadOnly(): bool
+	{
+		return $this->readOnly;
 	}
 
 

--- a/src/PhpGenerator/Closure.php
+++ b/src/PhpGenerator/Closure.php
@@ -14,13 +14,10 @@ use Nette;
 
 /**
  * Closure.
- *
- * @property-deprecated string $body
  */
-final class Closure
+final class Closure extends FunctionLike
 {
 	use Nette\SmartObject;
-	use Traits\FunctionLike;
 	use Traits\AttributeAware;
 
 	/** @var Parameter[] */

--- a/src/PhpGenerator/Extractor.php
+++ b/src/PhpGenerator/Extractor.php
@@ -246,6 +246,7 @@ final class Extractor
 
 		$class->setFinal($node->isFinal());
 		$class->setAbstract($node->isAbstract());
+		$class->setReadOnly(method_exists($node, 'isReadonly') && $node->isReadonly());
 		$this->addCommentAndAttributes($class, $node);
 		return $class;
 	}

--- a/src/PhpGenerator/Extractor.php
+++ b/src/PhpGenerator/Extractor.php
@@ -108,7 +108,7 @@ final class Extractor
 	 */
 	private function prepareReplacements(array $nodes): array
 	{
-		$start = $nodes[0]->getStartFilePos();
+		$start = $this->getNodeStartPos($nodes[0]);
 		$replacements = [];
 		(new NodeFinder)->find($nodes, function (Node $node) use (&$replacements, $start) {
 			if ($node instanceof Node\Name\FullyQualified) {
@@ -430,7 +430,15 @@ final class Extractor
 
 	private function getNodeContents(Node ...$nodes): string
 	{
-		$start = $nodes[0]->getStartFilePos();
+		$start = $this->getNodeStartPos($nodes[0]);
 		return substr($this->code, $start, end($nodes)->getEndFilePos() - $start + 1);
+	}
+
+
+	private function getNodeStartPos(Node $node): int
+	{
+		return ($comments = $node->getComments())
+			? $comments[0]->getStartFilePos()
+			: $node->getStartFilePos();
 	}
 }

--- a/src/PhpGenerator/Extractor.php
+++ b/src/PhpGenerator/Extractor.php
@@ -385,7 +385,7 @@ final class Extractor
 	}
 
 
-	private function setupFunction(GlobalFunction|Method $function, Node\FunctionLike $node): void
+	private function setupFunction(FunctionLike $function, Node\FunctionLike $node): void
 	{
 		$function->setReturnReference($node->returnsByRef());
 		$function->setReturnType($node->getReturnType() ? $this->toPhp($node->getReturnType()) : null);

--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -194,7 +194,7 @@ final class Factory
 	}
 
 
-	public function fromCallable(callable $from): Method|GlobalFunction|Closure
+	public function fromCallable(callable $from): FunctionLike
 	{
 		$ref = Nette\Utils\Callback::toReflection($from);
 		return $ref instanceof \ReflectionMethod

--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -32,7 +32,8 @@ final class Factory
 		\ReflectionClass $from,
 		bool $withBodies = false,
 		?bool $materializeTraits = null,
-	): ClassLike {
+	): ClassLike
+	{
 		if ($materializeTraits !== null) {
 			trigger_error(__METHOD__ . '() parameter $materializeTraits has been removed (is always false).', E_USER_DEPRECATED);
 		}

--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -70,7 +70,7 @@ final class Factory
 		}
 
 		$class->setComment(Helpers::unformatDocComment((string) $from->getDocComment()));
-		$class->setAttributes(self::getAttributes($from));
+		$class->setAttributes($this->getAttributes($from));
 		if ($from->getParentClass()) {
 			$class->setExtends($from->getParentClass()->name);
 			$class->setImplements(array_diff($class->getImplements(), $from->getParentClass()->getInterfaceNames()));
@@ -160,7 +160,7 @@ final class Factory
 		$method->setReturnReference($from->returnsReference());
 		$method->setVariadic($from->isVariadic());
 		$method->setComment(Helpers::unformatDocComment((string) $from->getDocComment()));
-		$method->setAttributes(self::getAttributes($from));
+		$method->setAttributes($this->getAttributes($from));
 		$method->setReturnType((string) $from->getReturnType());
 
 		return $method;
@@ -177,7 +177,7 @@ final class Factory
 			$function->setComment(Helpers::unformatDocComment((string) $from->getDocComment()));
 		}
 
-		$function->setAttributes(self::getAttributes($from));
+		$function->setAttributes($this->getAttributes($from));
 		$function->setReturnType((string) $from->getReturnType());
 
 		if ($withBody) {
@@ -196,8 +196,8 @@ final class Factory
 	{
 		$ref = Nette\Utils\Callback::toReflection($from);
 		return $ref instanceof \ReflectionMethod
-			? self::fromMethodReflection($ref)
-			: self::fromFunctionReflection($ref);
+			? $this->fromMethodReflection($ref)
+			: $this->fromFunctionReflection($ref);
 	}
 
 
@@ -226,7 +226,7 @@ final class Factory
 			$param->setNullable($param->isNullable() && $param->getDefaultValue() !== null);
 		}
 
-		$param->setAttributes(self::getAttributes($from));
+		$param->setAttributes($this->getAttributes($from));
 		return $param;
 	}
 
@@ -238,7 +238,7 @@ final class Factory
 		$const->setVisibility($this->getVisibility($from));
 		$const->setFinal(PHP_VERSION_ID >= 80100 ? $from->isFinal() : false);
 		$const->setComment(Helpers::unformatDocComment((string) $from->getDocComment()));
-		$const->setAttributes(self::getAttributes($from));
+		$const->setAttributes($this->getAttributes($from));
 		return $const;
 	}
 
@@ -248,7 +248,7 @@ final class Factory
 		$const = new EnumCase($from->name);
 		$const->setValue($from->getValue()->value ?? null);
 		$const->setComment(Helpers::unformatDocComment((string) $from->getDocComment()));
-		$const->setAttributes(self::getAttributes($from));
+		$const->setAttributes($this->getAttributes($from));
 		return $const;
 	}
 
@@ -265,7 +265,7 @@ final class Factory
 		$prop->setInitialized($from->hasType() && array_key_exists($prop->getName(), $defaults));
 		$prop->setReadOnly(PHP_VERSION_ID >= 80100 ? $from->isReadOnly() : false);
 		$prop->setComment(Helpers::unformatDocComment((string) $from->getDocComment()));
-		$prop->setAttributes(self::getAttributes($from));
+		$prop->setAttributes($this->getAttributes($from));
 		return $prop;
 	}
 

--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -55,6 +55,7 @@ final class Factory
 			$class = new ClassType($from->getShortName(), new PhpNamespace($from->getNamespaceName()));
 			$class->setFinal($from->isFinal() && $class->isClass());
 			$class->setAbstract($from->isAbstract() && $class->isClass());
+			$class->setReadOnly(PHP_VERSION_ID >= 80200 && $from->isReadOnly());
 		}
 
 		$ifaces = $from->getInterfaceNames();

--- a/src/PhpGenerator/FunctionLike.php
+++ b/src/PhpGenerator/FunctionLike.php
@@ -7,18 +7,18 @@
 
 declare(strict_types=1);
 
-namespace Nette\PhpGenerator\Traits;
+namespace Nette\PhpGenerator;
 
 use Nette;
-use Nette\PhpGenerator\Dumper;
-use Nette\PhpGenerator\Parameter;
 use Nette\Utils\Type;
 
 
 /**
- * @internal
+ * GlobalFunction/Closure/Method description.
+ *
+ * @property-deprecated string $body
  */
-trait FunctionLike
+abstract class FunctionLike
 {
 	private string $body = '';
 

--- a/src/PhpGenerator/GlobalFunction.php
+++ b/src/PhpGenerator/GlobalFunction.php
@@ -14,13 +14,10 @@ use Nette;
 
 /**
  * Global function.
- *
- * @property-deprecated string $body
  */
-final class GlobalFunction
+final class GlobalFunction extends FunctionLike
 {
 	use Nette\SmartObject;
-	use Traits\FunctionLike;
 	use Traits\NameAware;
 	use Traits\CommentAware;
 	use Traits\AttributeAware;

--- a/src/PhpGenerator/Helpers.php
+++ b/src/PhpGenerator/Helpers.php
@@ -170,14 +170,19 @@ final class Helpers
 
 	public static function validateType(?string $type, bool &$nullable): ?string
 	{
+		$nullable = false;
 		if ($type === '' || $type === null) {
 			return null;
 		}
 
-		if (!preg_match('#(?:
-			\?[\w\\\\]+|
-			[\w\\\\]+ (?: (&[\w\\\\]+)* | (\|[\w\\\\]+)* )
-		)()$#xAD', $type)) {
+		if (!preg_match(<<<'XX'
+			~(?n)
+			(
+				\?? (?<type> [\w\\]+)|
+				(?<intersection> (?&type) (& (?&type))+  )|
+				(?<upart> (?&type) | \( (?&intersection) \) )  (\| (?&upart) )+
+			)$~xAD
+			XX, $type)) {
 			throw new Nette\InvalidArgumentException("Value '$type' is not valid type.");
 		}
 

--- a/src/PhpGenerator/Method.php
+++ b/src/PhpGenerator/Method.php
@@ -14,13 +14,10 @@ use Nette;
 
 /**
  * Class method.
- *
- * @property-deprecated string|null $body
  */
-final class Method
+final class Method extends FunctionLike
 {
 	use Nette\SmartObject;
-	use Traits\FunctionLike;
 	use Traits\NameAware;
 	use Traits\VisibilityAware;
 	use Traits\CommentAware;
@@ -92,7 +89,11 @@ final class Method
 			$param->setDefaultValue($defaultValue);
 		}
 
-		return $this->parameters[$name] = $param;
+		$params = $this->getParameters();
+		$params[$name] = $param;
+		$this->setParameters($params);
+
+		return $param;
 	}
 
 

--- a/src/PhpGenerator/PhpNamespace.php
+++ b/src/PhpGenerator/PhpNamespace.php
@@ -162,7 +162,7 @@ final class PhpNamespace
 	/** @return string[] */
 	public function getUses(string $of = self::NameNormal): array
 	{
-		asort($this->aliases[$of]);
+		uasort($this->aliases[$of], fn(string $a, string $b): int => strtr($a, '\\', ' ') <=> strtr($b, '\\', ' '));
 		return array_filter(
 			$this->aliases[$of],
 			fn($name, $alias) => strcasecmp(($this->name ? $this->name . '\\' : '') . $alias, $name),

--- a/src/PhpGenerator/PhpNamespace.php
+++ b/src/PhpGenerator/PhpNamespace.php
@@ -162,7 +162,7 @@ final class PhpNamespace
 	/** @return string[] */
 	public function getUses(string $of = self::NameNormal): array
 	{
-		uasort($this->aliases[$of], fn(string $a, string $b): int => strtr($a, '\\', ' ') <=> strtr($b, '\\', ' '));
+		uasort($this->aliases[$of], fn(string $a, string $b): int => strtolower(strtr($a, '\\', ' ')) <=> strtolower(strtr($b, '\\', ' ')));
 		return array_filter(
 			$this->aliases[$of],
 			fn($name, $alias) => strcasecmp(($this->name ? $this->name . '\\' : '') . $alias, $name),

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -385,7 +385,7 @@ class Printer
 	}
 
 
-	private function printReturnType(Closure|GlobalFunction|Method $function): string
+	private function printReturnType(FunctionLike $function): string
 	{
 		return ($tmp = $this->printType($function->getReturnType(), $function->isReturnNullable()))
 			? $this->returnTypeColon . $tmp

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -133,7 +133,8 @@ class Printer
 	public function printClass(
 		ClassType|InterfaceType|TraitType|EnumType $class,
 		?PhpNamespace $namespace = null,
-	): string {
+	): string
+	{
 		$this->namespace = $this->resolveTypes ? $namespace : null;
 		$class->validate();
 		$resolver = $this->namespace

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -226,6 +226,7 @@ class Printer
 		if ($class instanceof ClassType) {
 			$line[] = $class->isAbstract() ? 'abstract' : null;
 			$line[] = $class->isFinal() ? 'final' : null;
+			$line[] = $class->isReadOnly() ? 'readonly' : null;
 		}
 
 		$line[] = match (true) {

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -49,7 +49,7 @@ class Printer
 		$body = ltrim(rtrim(Strings::normalize($body)) . "\n");
 
 		return $this->printDocComment($function)
-			. self::printAttributes($function->getAttributes())
+			. $this->printAttributes($function->getAttributes())
 			. $line
 			. $this->printParameters($function, strlen($line) + strlen($returnType) + 2) // 2 = parentheses
 			. $returnType
@@ -72,7 +72,7 @@ class Printer
 		$body = Helpers::simplifyTaggedNames($closure->getBody(), $this->namespace);
 		$body = ltrim(rtrim(Strings::normalize($body)) . "\n");
 
-		return self::printAttributes($closure->getAttributes(), inline: true)
+		return $this->printAttributes($closure->getAttributes(), inline: true)
 			. 'function '
 			. ($closure->getReturnReference() ? '&' : '')
 			. $this->printParameters($closure)
@@ -93,7 +93,7 @@ class Printer
 
 		$body = Helpers::simplifyTaggedNames($closure->getBody(), $this->namespace);
 
-		return self::printAttributes($closure->getAttributes())
+		return $this->printAttributes($closure->getAttributes())
 			. 'fn'
 			. ($closure->getReturnReference() ? '&' : '')
 			. $this->printParameters($closure)
@@ -120,7 +120,7 @@ class Printer
 		$braceOnNextLine = $this->bracesOnNextLine && !str_contains($params, "\n");
 
 		return $this->printDocComment($method)
-			. self::printAttributes($method->getAttributes())
+			. $this->printAttributes($method->getAttributes())
 			. $line
 			. $params
 			. $returnType
@@ -159,7 +159,7 @@ class Printer
 			foreach ($class->getCases() as $case) {
 				$enumType ??= is_scalar($case->getValue()) ? get_debug_type($case->getValue()) : null;
 				$cases[] = $this->printDocComment($case)
-					. self::printAttributes($case->getAttributes())
+					. $this->printAttributes($case->getAttributes())
 					. 'case ' . $case->getName()
 					. ($case->getValue() === null ? '' : ' = ' . $this->dump($case->getValue()))
 					. ";\n";
@@ -174,7 +174,7 @@ class Printer
 					. 'const ' . $const->getName() . ' = ';
 
 				$consts[] = $this->printDocComment($const)
-					. self::printAttributes($const->getAttributes())
+					. $this->printAttributes($const->getAttributes())
 					. $def
 					. $this->dump($const->getValue(), strlen($def)) . ";\n";
 			}
@@ -205,7 +205,7 @@ class Printer
 					. '$' . $property->getName());
 
 				$properties[] = $this->printDocComment($property)
-					. self::printAttributes($property->getAttributes())
+					. $this->printAttributes($property->getAttributes())
 					. $def
 					. ($property->getValue() === null && !$property->isInitialized()
 						? ''
@@ -243,7 +243,7 @@ class Printer
 		$line[] = $class->getName() ? null : '{';
 
 		return $this->printDocComment($class)
-			. self::printAttributes($class->getAttributes())
+			. $this->printAttributes($class->getAttributes())
 			. implode(' ', array_filter($line))
 			. ($class->getName() ? "\n{\n" : "\n")
 			. ($members ? $this->indent(implode("\n", $members)) : '')
@@ -333,7 +333,7 @@ class Printer
 			$promoted = $param instanceof PromotedParameter ? $param : null;
 			$params[] =
 				($promoted ? $this->printDocComment($promoted) : '')
-				. ($attrs = self::printAttributes($param->getAttributes(), inline: true))
+				. ($attrs = $this->printAttributes($param->getAttributes(), inline: true))
 				. ($promoted ?
 					($promoted->getVisibility() ?: 'public')
 					. ($promoted->isReadOnly() && $type ? ' readonly' : '')

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -167,7 +167,13 @@ class Printer
 		}
 
 		$consts = [];
-		if ($class instanceof ClassType || $class instanceof InterfaceType || $class instanceof EnumType) {
+		$methods = [];
+		if (
+			$class instanceof ClassType
+			|| $class instanceof InterfaceType
+			|| $class instanceof TraitType
+			|| $class instanceof EnumType
+		) {
 			foreach ($class->getConstants() as $const) {
 				$def = ($const->isFinal() ? 'final ' : '')
 					. ($const->getVisibility() ? $const->getVisibility() . ' ' : '')
@@ -178,15 +184,7 @@ class Printer
 					. $def
 					. $this->dump($const->getValue(), strlen($def)) . ";\n";
 			}
-		}
 
-		$methods = [];
-		if (
-			$class instanceof ClassType
-			|| $class instanceof InterfaceType
-			|| $class instanceof EnumType
-			|| $class instanceof TraitType
-		) {
 			foreach ($class->getMethods() as $method) {
 				$methods[] = $this->printMethod($method, $namespace, $class->isInterface());
 			}

--- a/src/PhpGenerator/TraitType.php
+++ b/src/PhpGenerator/TraitType.php
@@ -20,6 +20,7 @@ use Nette;
  */
 final class TraitType extends ClassLike
 {
+	use Traits\ConstantsAware;
 	use Traits\MethodsAware;
 	use Traits\PropertiesAware;
 	use Traits\TraitsAware;
@@ -28,6 +29,7 @@ final class TraitType extends ClassLike
 	{
 		$name = $member->getName();
 		[$type, $n] = match (true) {
+			$member instanceof Constant => ['consts', $name],
 			$member instanceof Method => ['methods', strtolower($name)],
 			$member instanceof Property => ['properties', $name],
 			$member instanceof TraitUse => ['traits', $name],
@@ -43,6 +45,7 @@ final class TraitType extends ClassLike
 	public function __clone()
 	{
 		$clone = fn($item) => clone $item;
+		$this->consts = array_map($clone, $this->consts);
 		$this->methods = array_map($clone, $this->methods);
 		$this->properties = array_map($clone, $this->properties);
 		$this->traits = array_map($clone, $this->traits);

--- a/src/PhpGenerator/Type.php
+++ b/src/PhpGenerator/Type.php
@@ -27,6 +27,7 @@ class Type
 		Void = 'void',
 		Never = 'never',
 		Mixed = 'mixed',
+		True = 'true',
 		False = 'false',
 		Null = 'null',
 		Self = 'self',

--- a/src/PhpGenerator/Type.php
+++ b/src/PhpGenerator/Type.php
@@ -16,22 +16,41 @@ namespace Nette\PhpGenerator;
 class Type
 {
 	public const
-		STRING = 'string',
-		INT = 'int',
-		FLOAT = 'float',
-		BOOL = 'bool',
-		ARRAY = 'array',
-		OBJECT = 'object',
-		CALLABLE = 'callable',
-		ITERABLE = 'iterable',
-		VOID = 'void',
-		NEVER = 'never',
-		MIXED = 'mixed',
-		FALSE = 'false',
-		NULL = 'null',
-		SELF = 'self',
-		PARENT = 'parent',
-		STATIC = 'static';
+		String = 'string',
+		Int = 'int',
+		Float = 'float',
+		Bool = 'bool',
+		Array = 'array',
+		Object = 'object',
+		Callable = 'callable',
+		Iterable = 'iterable',
+		Void = 'void',
+		Never = 'never',
+		Mixed = 'mixed',
+		False = 'false',
+		Null = 'null',
+		Self = 'self',
+		Parent = 'parent',
+		Static = 'static';
+
+	/** @deprecated */
+	public const
+		STRING = self::String,
+		INT = self::Int,
+		FLOAT = self::Float,
+		BOOL = self::Bool,
+		ARRAY = self::Array,
+		OBJECT = self::Object,
+		CALLABLE = self::Callable,
+		ITERABLE = self::Iterable,
+		VOID = self::Void,
+		NEVER = self::Never,
+		MIXED = self::Mixed,
+		FALSE = self::False,
+		NULL = self::Null,
+		SELF = self::Self,
+		PARENT = self::Parent,
+		STATIC = self::Static;
 
 
 	public static function nullable(string $type, bool $state = true): string

--- a/tests/PhpGenerator/ClassType.from.82.phpt
+++ b/tests/PhpGenerator/ClassType.from.82.phpt
@@ -13,5 +13,6 @@ require __DIR__ . '/../bootstrap.php';
 require __DIR__ . '/fixtures/classes.82.php';
 
 $res[] = ClassType::from(new Abc\Class13);
+$res[] = ClassType::from(Abc\Trait13::class);
 
 sameFile(__DIR__ . '/expected/ClassType.from.82.expect', implode("\n", $res));

--- a/tests/PhpGenerator/ClassType.from.82.phpt
+++ b/tests/PhpGenerator/ClassType.from.82.phpt
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @phpVersion 8.2
+ */
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\ClassType;
+
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/fixtures/classes.82.php';
+
+$res[] = ClassType::from(new Abc\Class13);
+
+sameFile(__DIR__ . '/expected/ClassType.from.82.expect', implode("\n", $res));

--- a/tests/PhpGenerator/ClassType.phpt
+++ b/tests/PhpGenerator/ClassType.phpt
@@ -60,16 +60,16 @@ $class->addProperty('order')
 	->setValue(new Literal('RecursiveIteratorIterator::SELF_FIRST'));
 
 $class->addProperty('typed1')
-	->setType(Type::ARRAY)
+	->setType(Type::Array)
 	->setReadOnly();
 
 $class->addProperty('typed2')
-	->setType(Type::ARRAY)
+	->setType(Type::Array)
 	->setNullable()
 	->setInitialized();
 
 $class->addProperty('typed3')
-	->setType(Type::ARRAY)
+	->setType(Type::Array)
 	->setValue(null);
 
 $p = $class->addProperty('sections', ['first' => true])
@@ -128,7 +128,7 @@ $method->addParameter('item');
 
 $method->addParameter('res', null)
 		->setReference(true)
-		->setType(Type::union(Type::ARRAY, 'null'));
+		->setType(Type::union(Type::Array, 'null'));
 
 $method->addParameter('bar', null)
 		->setType('stdClass|string')

--- a/tests/PhpGenerator/Extractor.extractAll.phpt
+++ b/tests/PhpGenerator/Extractor.extractAll.phpt
@@ -15,6 +15,9 @@ sameFile(__DIR__ . '/expected/Extractor.classes.expect', (string) $file);
 $file = (new Extractor(file_get_contents(__DIR__ . '/fixtures/classes.81.php')))->extractAll();
 sameFile(__DIR__ . '/expected/Extractor.classes.81.expect', (string) $file);
 
+$file = (new Extractor(file_get_contents(__DIR__ . '/fixtures/classes.82.php')))->extractAll();
+sameFile(__DIR__ . '/expected/Extractor.classes.82.expect', (string) $file);
+
 $file = (new Extractor(file_get_contents(__DIR__ . '/fixtures/enum.php')))->extractAll();
 sameFile(__DIR__ . '/expected/Extractor.enum.expect', (string) $file);
 

--- a/tests/PhpGenerator/Extractor.extractAll.phpt
+++ b/tests/PhpGenerator/Extractor.extractAll.phpt
@@ -24,56 +24,8 @@ sameFile(__DIR__ . '/expected/Extractor.traits.expect', (string) $file);
 $file = (new Extractor(file_get_contents(__DIR__ . '/fixtures/bodies.php')))->extractAll();
 sameFile(__DIR__ . '/expected/Extractor.bodies.expect', (string) $file);
 
-$file = (new Extractor(<<<'XX'
-	<?php
-	class Class1
-	{
-		public function foo()
-		{
-			new class {
-				function bar() {
-				}
-			};
-		}
-	}
-
-	function () {};
-
-	/** doc */
-	function foo(A $a): B|C
-	{
-		function bar()
-		{
-		}
-	}
-
-	XX))->extractAll();
-Assert::type(Nette\PhpGenerator\PhpFile::class, $file);
-Assert::match(<<<'XX'
-	<?php
-
-	class Class1
-	{
-		public function foo()
-		{
-			new class {
-				function bar() {
-				}
-			};
-		}
-	}
-
-	/**
-	 * doc
-	 */
-	function foo(A $a): B|C
-	{
-		function bar()
-		{
-		}
-	}
-	XX, (string) $file);
-
+$file = (new Extractor(file_get_contents(__DIR__ . '/fixtures/extractor.php')))->extractAll();
+sameFile(__DIR__ . '/expected/Extractor.expect', (string) $file);
 
 Assert::exception(function () {
 	(new Extractor(''));

--- a/tests/PhpGenerator/Helpers.validateType.phpt
+++ b/tests/PhpGenerator/Helpers.validateType.phpt
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\Helpers;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$foo = false;
+Assert::null(Helpers::validateType('', $foo));
+Assert::null(Helpers::validateType(null, $foo));
+Assert::same('Foo', Helpers::validateType('Foo', $foo));
+Assert::same('Foo\Bar', Helpers::validateType('Foo\Bar', $foo));
+Assert::same('\Foo\Bar', Helpers::validateType('\Foo\Bar', $foo));
+Assert::same('Foo', Helpers::validateType('?Foo', $foo));
+Assert::true($foo);
+Assert::same('Foo|Bar', Helpers::validateType('Foo|Bar', $foo));
+Assert::same('Foo&Bar\X', Helpers::validateType('Foo&Bar\X', $foo));
+Assert::same('(Foo&Bar\X)|Baz', Helpers::validateType('(Foo&Bar\X)|Baz', $foo));
+Assert::same('Abc\C|(Abc\X&Abc\D)|null', Helpers::validateType('Abc\C|(Abc\X&Abc\D)|null', $foo));
+
+Assert::exception(
+	fn() => Helpers::validateType('-', $foo),
+	Nette\InvalidArgumentException::class,
+);
+
+Assert::exception(
+	fn() => Helpers::validateType('?Foo|Bar', $foo),
+	Nette\InvalidArgumentException::class,
+);
+
+Assert::exception(
+	fn() => Helpers::validateType('(Foo)', $foo),
+	Nette\InvalidArgumentException::class,
+);
+
+Assert::exception(
+	fn() => Helpers::validateType('(Foo&Bar)', $foo),
+	Nette\InvalidArgumentException::class,
+);

--- a/tests/PhpGenerator/Method.returnTypes.phpt
+++ b/tests/PhpGenerator/Method.returnTypes.phpt
@@ -13,8 +13,7 @@ namespace A
 	}
 }
 
-namespace
-{
+namespace {
 	use Nette\PhpGenerator\Method;
 	use Tester\Assert;
 

--- a/tests/PhpGenerator/Method.scalarParameters.phpt
+++ b/tests/PhpGenerator/Method.scalarParameters.phpt
@@ -39,8 +39,8 @@ Assert::same('float', $method->getParameters()['d']->getType());
 
 $method = (new Method('create'))
 	->setBody('return null;');
-$method->addParameter('a')->setType(Type::STRING);
-$method->addParameter('b')->setType(Type::BOOL);
+$method->addParameter('a')->setType(Type::String);
+$method->addParameter('b')->setType(Type::Bool);
 
 same(
 	'function create(string $a, bool $b)

--- a/tests/PhpGenerator/Printer.use-order.phpt
+++ b/tests/PhpGenerator/Printer.use-order.phpt
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\PhpNamespace;
+use Nette\PhpGenerator\Printer;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$printer = new Printer;
+$namespace = new PhpNamespace('Foo');
+$namespace->addUse('Example\Foo\EmailAlias\Bar');
+$namespace->addUse('Example\Foo\Email\Test');
+$namespace->addUse('Example\Foo\MyClass');
+
+Assert::match(
+	<<<'XX'
+		namespace Foo;
+
+		use Example\Foo\Email\Test;
+		use Example\Foo\EmailAlias\Bar;
+		use Example\Foo\MyClass;
+
+		XX,
+	$printer->printNamespace($namespace),
+);

--- a/tests/PhpGenerator/Type.phpt
+++ b/tests/PhpGenerator/Type.phpt
@@ -8,7 +8,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-Assert::same('A|string', Type::union(A::class, Type::STRING));
+Assert::same('A|string', Type::union(A::class, Type::String));
 
 Assert::same('?A', Type::nullable(A::class));
 Assert::same('?A', Type::nullable(A::class, true));

--- a/tests/PhpGenerator/expected/ClassType.from.82.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.82.expect
@@ -1,5 +1,8 @@
 readonly class Class13
 {
+	public function func(C|(X&D)|null $foo): (A&B)|null
+	{
+	}
 }
 
 trait Trait13

--- a/tests/PhpGenerator/expected/ClassType.from.82.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.82.expect
@@ -1,0 +1,3 @@
+readonly class Class13
+{
+}

--- a/tests/PhpGenerator/expected/ClassType.from.82.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.82.expect
@@ -1,3 +1,8 @@
 readonly class Class13
 {
 }
+
+trait Trait13
+{
+	public const FOO = 123;
+}

--- a/tests/PhpGenerator/expected/ClassType.from.bodies.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.bodies.expect
@@ -27,6 +27,7 @@ abstract class Class7
 
 	public function long()
 	{
+		// comment
 		if ($member instanceof Method) {
 			$s = [1, 2, 3];
 		}
@@ -39,6 +40,7 @@ abstract class Class7
 
 	public function resolving($a = Abc\a\FOO, self $b = null, $c = self::FOO)
 	{
+		// constants
 		echo FOO;
 		echo \FOO;
 		echo a\FOO;

--- a/tests/PhpGenerator/expected/Extractor.bodies.expect
+++ b/tests/PhpGenerator/expected/Extractor.bodies.expect
@@ -37,6 +37,7 @@ abstract class Class7
 
 	function long()
 	{
+		// comment
 		if ($member instanceof Method) {
 			$s = [1, 2, 3];
 		}
@@ -49,6 +50,7 @@ abstract class Class7
 
 	function resolving($a = a\FOO, self $b = null, $c = self::FOO)
 	{
+		// constants
 		echo FOO;
 		echo \FOO;
 		echo a\FOO;

--- a/tests/PhpGenerator/expected/Extractor.bodies.resolving.expect
+++ b/tests/PhpGenerator/expected/Extractor.bodies.resolving.expect
@@ -32,6 +32,7 @@ abstract class Class7
 
 	function long()
 	{
+		// comment
 		if ($member instanceof \Abc\Method) {
 			$s = [1, 2, 3];
 		}
@@ -44,6 +45,7 @@ abstract class Class7
 
 	function resolving($a = \Abc\a\FOO, self $b = null, $c = self::FOO)
 	{
+		// constants
 		echo FOO;
 		echo \FOO;
 		echo \Abc\a\FOO;

--- a/tests/PhpGenerator/expected/Extractor.bodies.unresolving.expect
+++ b/tests/PhpGenerator/expected/Extractor.bodies.unresolving.expect
@@ -32,6 +32,7 @@ abstract class Class7
 
 	function long()
 	{
+		// comment
 		if ($member instanceof \Abc\Method) {
 			$s = [1, 2, 3];
 		}
@@ -44,6 +45,7 @@ abstract class Class7
 
 	function resolving($a = \Abc\a\FOO, self $b = null, $c = self::FOO)
 	{
+		// constants
 		echo FOO;
 		echo \FOO;
 		echo \Abc\a\FOO;

--- a/tests/PhpGenerator/expected/Extractor.classes.82.expect
+++ b/tests/PhpGenerator/expected/Extractor.classes.82.expect
@@ -6,6 +6,9 @@ namespace Abc;
 
 readonly class Class13
 {
+	public function func(C|(X&D)|null $foo): (A&B)|null
+	{
+	}
 }
 
 trait Trait13

--- a/tests/PhpGenerator/expected/Extractor.classes.82.expect
+++ b/tests/PhpGenerator/expected/Extractor.classes.82.expect
@@ -7,3 +7,8 @@ namespace Abc;
 readonly class Class13
 {
 }
+
+trait Trait13
+{
+	public const FOO = 123;
+}

--- a/tests/PhpGenerator/expected/Extractor.classes.82.expect
+++ b/tests/PhpGenerator/expected/Extractor.classes.82.expect
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abc;
+
+readonly class Class13
+{
+}

--- a/tests/PhpGenerator/expected/Extractor.expect
+++ b/tests/PhpGenerator/expected/Extractor.expect
@@ -9,6 +9,27 @@ class Class1
 			}
 		};
 	}
+
+
+	function comment1()
+	{
+		/** comment */
+		$a = 10;
+	}
+
+
+	function comment2()
+	{
+		// comment
+		"bar";
+	}
+
+
+	function comment3()
+	{
+		// comment
+		Foo\Bar::XX;
+	}
 }
 
 /**

--- a/tests/PhpGenerator/expected/Extractor.expect
+++ b/tests/PhpGenerator/expected/Extractor.expect
@@ -1,0 +1,22 @@
+<?php
+
+class Class1
+{
+	public function foo()
+	{
+		new class {
+			function bar() {
+			}
+		};
+	}
+}
+
+/**
+ * doc
+ */
+function foo(A $a): B|C
+{
+	function bar()
+	{
+	}
+}

--- a/tests/PhpGenerator/fixtures/classes.82.php
+++ b/tests/PhpGenerator/fixtures/classes.82.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abc;
+
+readonly class Class13
+{
+}

--- a/tests/PhpGenerator/fixtures/classes.82.php
+++ b/tests/PhpGenerator/fixtures/classes.82.php
@@ -7,3 +7,9 @@ namespace Abc;
 readonly class Class13
 {
 }
+
+
+trait Trait13
+{
+    public const FOO = 123;
+}

--- a/tests/PhpGenerator/fixtures/classes.82.php
+++ b/tests/PhpGenerator/fixtures/classes.82.php
@@ -6,6 +6,9 @@ namespace Abc;
 
 readonly class Class13
 {
+	public function func(C|(X&D)|null $foo): (A&B)|null
+	{
+	}
 }
 
 

--- a/tests/PhpGenerator/fixtures/extractor.php
+++ b/tests/PhpGenerator/fixtures/extractor.php
@@ -8,6 +8,24 @@ class Class1
 			}
 		};
 	}
+
+	function comment1()
+	{
+		/** comment */
+		$a = 10;
+	}
+
+	function comment2()
+	{
+		// comment
+		'bar';
+	}
+
+	function comment3()
+	{
+		// comment
+		Foo\Bar::XX;
+	}
 }
 
 function () {};

--- a/tests/PhpGenerator/fixtures/extractor.php
+++ b/tests/PhpGenerator/fixtures/extractor.php
@@ -1,0 +1,21 @@
+<?php
+class Class1
+{
+	public function foo()
+	{
+		new class {
+			function bar() {
+			}
+		};
+	}
+}
+
+function () {};
+
+/** doc */
+function foo(A $a): B|C
+{
+	function bar()
+	{
+	}
+}


### PR DESCRIPTION
- bug fix
- BC break? no

Before

```php
use App\QueryCostSet;
use App\QueryCostsBootstrapped;
```

After

```php
use App\QueryCostsBootstrapped;
use App\QueryCostSet;
```