### PR TITLE
Add method to check if a class has a specific constant (by name)

### DIFF
--- a/src/PhpGenerator/Traits/ConstantsAware.php
+++ b/src/PhpGenerator/Traits/ConstantsAware.php
@@ -62,4 +62,9 @@ trait ConstantsAware
 		unset($this->consts[$name]);
 		return $this;
 	}
+
+    public function hasConstant(string $name): bool
+    {
+        return isset($this->consts[$name]);
+    }
 }


### PR DESCRIPTION
The Method and Property traits already had a check like this, this commit adds the same functionality for constants.

- new feature
- BC break? no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

Saw this method was missing when working with constants.
