### PR TITLE
Support union type in `Type::nullable()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -536,7 +536,9 @@ Each type or union/intersection type can be passed as a string, you can also use
 use Nette\PhpGenerator\Type;
 
 $member->setType('array'); // or Type::Array;
-$member->setType('array|string'); // or Type::union('array', 'string')
+$member->setType('?array'); // or Type::nullable(Type::Array);
+$member->setType('array|string'); // or Type::union(Type::Array, Type::String)
+$member->setType('array|string|null'); // or Type::nullable(Type::union(Type::Array, Type::String))
 $member->setType('Foo&Bar'); // or Type::intersection(Foo::class, Bar::class)
 $member->setType(null); // removes type
 ```

--- a/src/PhpGenerator/Type.php
+++ b/src/PhpGenerator/Type.php
@@ -85,7 +85,25 @@ class Type
 
 	public static function nullable(string $type, bool $nullable = true): string
 	{
-		return ($nullable ? '?' : '') . ltrim($type, '?');
+		if (! str_contains($type, '|')) {
+			return ($nullable ? '?' : '') . ltrim($type, '?');
+		}
+
+		// Union type
+		$types = explode('|', $type);
+		if (in_array('null', $types)) {
+			if ($nullable) {
+				return $type;
+			}
+			$types = array_diff($types, ['null']);
+		} else {
+			if (!$nullable) {
+				return $type;
+			}
+			$types[] = 'null';
+		}
+
+		return implode('|', $types);
 	}
 
 

--- a/tests/PhpGenerator/Type.phpt
+++ b/tests/PhpGenerator/Type.phpt
@@ -6,12 +6,27 @@ use Nette\PhpGenerator\Type;
 use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
+// Nullable
+Assert::same('?int', Type::nullable(Type::Int));
+Assert::same('int', Type::nullable(Type::Int, nullable: false));
 
+Assert::same('?int', Type::nullable('?int'));
+Assert::same('int', Type::nullable('?int', nullable: false));
+
+Assert::same('int|float|string|null', Type::nullable('int|float|string'));
+Assert::same('int|float|string', Type::nullable('int|float|string', nullable: false));
+
+Assert::same('null|int|float|string', Type::nullable('null|int|float|string'));
+Assert::same('int|float|string', Type::nullable('null|int|float|string', nullable: false));
+
+Assert::same('int|float|string|null', Type::nullable('int|float|string|null'));
+Assert::same('int|float|string', Type::nullable('int|float|string|null', nullable: false));
+
+Assert::same('int|float|null|string', Type::nullable('int|float|null|string'));
+Assert::same('int|float|string', Type::nullable('int|float|null|string', nullable: false));
+
+// Union
 Assert::same('A|string', Type::union(A::class, Type::String));
 
-Assert::same('?A', Type::nullable(A::class));
-Assert::same('?A', Type::nullable(A::class));
-Assert::same('A', Type::nullable(A::class, nullable: false));
-
-Assert::same('?A', Type::nullable('?A'));
-Assert::same('A', Type::nullable('?A', nullable: false));
+// Intersection
+Assert::same('A&string', Type::intersection(A::class, Type::String));


### PR DESCRIPTION
- new feature: fix #139 
- BC break? no
- doc: in readme.md

I did some benchmarks. `in_array` vs `preg_replace` approaches are almost identical in terms of performance (very fast). Got the simplest implementation with `explode`, `in_array` and `array_diff`.