### PR TITLE
Fixed falsy Attribute Parameters aren't printed

### DIFF
--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -422,7 +422,7 @@ class Printer
 		foreach ($attrs as $attr) {
 			$args = $this->dumper->format('...?:', $attr->getArguments());
 			$args = Helpers::simplifyTaggedNames($args, $this->namespace);
-			$items[] = $this->printType($attr->getName(), nullable: false) . ($args ? "($args)" : '');
+			$items[] = $this->printType($attr->getName(), nullable: false) . ($args === '' ? "($args)" : '');
 			$inline = $inline && !str_contains($args, "\n");
 		}
 

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -422,7 +422,7 @@ class Printer
 		foreach ($attrs as $attr) {
 			$args = $this->dumper->format('...?:', $attr->getArguments());
 			$args = Helpers::simplifyTaggedNames($args, $this->namespace);
-			$items[] = $this->printType($attr->getName(), nullable: false) . ($args === '' ? "($args)" : '');
+			$items[] = $this->printType($attr->getName(), nullable: false) . ($args !== '' ? "($args)" : '');
 			$inline = $inline && !str_contains($args, "\n");
 		}
 

--- a/tests/PhpGenerator/Printer.attribute.phpt
+++ b/tests/PhpGenerator/Printer.attribute.phpt
@@ -3,24 +3,21 @@
 declare(strict_types=1);
 
 use Nette\PhpGenerator\ClassType;
-use Nette\PhpGenerator\Printer;
 use Tester\Assert;
 
 require __DIR__ . '/../bootstrap.php';
 
-#[Attribute]
-class MyAttribute
-{
-}
-
-
-$printer = new Printer;
 
 $classy = (new ClassType('Classy'))
-  ->addAttribute(MyAttribute::class, [0]);
+  ->addAttribute('MyAttribute', [0]);
 
-Assert::same('#[MyAttribute(0)]
-class Classy
-{
-}
-', $printer->printClass($classy));
+same(
+	<<<'XX'
+		#[MyAttribute(0)]
+		class Classy
+		{
+		}
+
+		XX,
+	(string) $classy,
+);

--- a/tests/PhpGenerator/Printer.attribute.phpt
+++ b/tests/PhpGenerator/Printer.attribute.phpt
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Nette\PhpGenerator\ClassType;
-use Nette\PhpGenerator\Literal;
 use Nette\PhpGenerator\Printer;
 use Tester\Assert;
 

--- a/tests/PhpGenerator/Printer.attribute.phpt
+++ b/tests/PhpGenerator/Printer.attribute.phpt
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\Literal;
+use Nette\PhpGenerator\Printer;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+#[Attribute]
+class MyAttribute
+{
+}
+
+
+$printer = new Printer;
+
+$classy = (new ClassType('Classy'))
+  ->addAttribute(MyAttribute::class, [0]);
+
+Assert::same('#[MyAttribute(0)]
+class Classy
+{
+}
+', $printer->printClass($classy));


### PR DESCRIPTION
- bug fix / new feature?   <!-- #140 -->
- BC break? yes/no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Now if you want to add an Attribute to for example a class you can have '0' as a parameter and it is printed correctly on the generated class
-->
