### PR TITLE
Make `ClassLike::from` return type assert the subclass type

### DIFF
--- a/src/PhpGenerator/ClassLike.php
+++ b/src/PhpGenerator/ClassLike.php
@@ -37,15 +37,14 @@ abstract class ClassLike
 	private ?PhpNamespace $namespace;
 	private ?string $name;
 
-
-	public static function from(string|object $class, bool $withBodies = false): self
+	public static function from(string|object $class, bool $withBodies = false): static
 	{
 		return (new Factory)
 			->fromClassReflection(new \ReflectionClass($class), $withBodies);
 	}
 
 
-	public static function fromCode(string $code): self
+	public static function fromCode(string $code): static
 	{
 		return (new Factory)
 			->fromClassCode($code);

--- a/src/PhpGenerator/ClassLike.php
+++ b/src/PhpGenerator/ClassLike.php
@@ -39,27 +39,28 @@ abstract class ClassLike
 
 	public static function from(string|object $class, bool $withBodies = false): static
 	{
-		$class = (new Factory)
+		$instance = (new Factory)
 			->fromClassReflection(new \ReflectionClass($class), $withBodies);
 
-        if (!$class instanceof static) {
-            throw new Nette\InvalidArgumentException("Object '$class' is not an instance of " . static::class);
+        if (!$instance instanceof static) {
+            $class = is_object($class) ? get_class($class) : $class;
+            throw new Nette\InvalidArgumentException("'$class' cannot be represented with " . static::class . ". Call " . get_class($instance) . "::" . __FUNCTION__ . "() or " . __METHOD__ . "() instead.");
         }
 
-        return $class;
+        return $instance;
 	}
 
 
 	public static function fromCode(string $code): static
 	{
-		$class = (new Factory)
+		$instance = (new Factory)
 			->fromClassCode($code);
 
-        if (!$class instanceof static) {
-            throw new Nette\InvalidArgumentException("Object '$class' is not an instance of " . static::class);
+        if (!$instance instanceof static) {
+            throw new Nette\InvalidArgumentException("Provided code cannot be represented with " . static::class . ". Call " . get_class($instance) . "::" . __FUNCTION__ . "() or " . __METHOD__ . "() instead.");
         }
 
-        return $class;
+        return $instance;
 	}
 
 

--- a/src/PhpGenerator/ClassLike.php
+++ b/src/PhpGenerator/ClassLike.php
@@ -39,15 +39,27 @@ abstract class ClassLike
 
 	public static function from(string|object $class, bool $withBodies = false): static
 	{
-		return (new Factory)
+		$class = (new Factory)
 			->fromClassReflection(new \ReflectionClass($class), $withBodies);
+
+        if (!$class instanceof static) {
+            throw new Nette\InvalidArgumentException("Object '$class' is not an instance of " . static::class);
+        }
+
+        return $class;
 	}
 
 
 	public static function fromCode(string $code): static
 	{
-		return (new Factory)
+		$class = (new Factory)
 			->fromClassCode($code);
+
+        if (!$class instanceof static) {
+            throw new Nette\InvalidArgumentException("Object '$class' is not an instance of " . static::class);
+        }
+
+        return $class;
 	}
 
 

--- a/tests/PhpGenerator/ClassLike.typecheck.phpt
+++ b/tests/PhpGenerator/ClassLike.typecheck.phpt
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\EnumType;
+use Nette\PhpGenerator\InterfaceType;
+use Nette\PhpGenerator\TraitType;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/fixtures/classes.php';
+
+Assert::exception(function () {
+	ClassType::from(Abc\Interface1::class);
+}, Nette\InvalidArgumentException::class, "'Abc\\Interface1' cannot be represented with Nette\\PhpGenerator\\ClassType. Call Nette\\PhpGenerator\\InterfaceType::from() or Nette\\PhpGenerator\\ClassLike::from() instead.");
+
+Assert::exception(function () {
+    TraitType::from(Abc\Class1::class);
+}, Nette\InvalidArgumentException::class, "'Abc\\Class1' cannot be represented with Nette\\PhpGenerator\\TraitType. Call Nette\\PhpGenerator\\ClassType::from() or Nette\\PhpGenerator\\ClassLike::from() instead.");
+
+Assert::exception(function () {
+    ClassType::fromCode("<?php interface I {}");
+}, Nette\InvalidArgumentException::class, "Provided code cannot be represented with Nette\\PhpGenerator\\ClassType. Call Nette\\PhpGenerator\\InterfaceType::fromCode() or Nette\\PhpGenerator\\ClassLike::fromCode() instead.");
+
+Assert::exception(function () {
+    InterfaceType::fromCode("<?php trait T {}");
+}, Nette\InvalidArgumentException::class, "Provided code cannot be represented with Nette\\PhpGenerator\\InterfaceType. Call Nette\\PhpGenerator\\TraitType::fromCode() or Nette\\PhpGenerator\\ClassLike::fromCode() instead.");

--- a/tests/PhpGenerator/ClassType.from.82.phpt
+++ b/tests/PhpGenerator/ClassType.from.82.phpt
@@ -7,11 +7,12 @@
 declare(strict_types=1);
 
 use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\TraitType;
 
 require __DIR__ . '/../bootstrap.php';
 require __DIR__ . '/fixtures/classes.82.php';
 
 $res[] = ClassType::from(new Abc\Class13);
-$res[] = ClassType::from(Abc\Trait13::class);
+$res[] = TraitType::from(Abc\Trait13::class);
 
 sameFile(__DIR__ . '/expected/ClassType.from.82.expect', implode("\n", $res));

--- a/tests/PhpGenerator/ClassType.from.phpt
+++ b/tests/PhpGenerator/ClassType.from.phpt
@@ -7,15 +7,16 @@
 declare(strict_types=1);
 
 use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\InterfaceType;
 use Nette\PhpGenerator\Factory;
 
 require __DIR__ . '/../bootstrap.php';
 require __DIR__ . '/fixtures/classes.php';
 
-$res[] = ClassType::from(Abc\Interface1::class);
-$res[] = ClassType::from(Abc\Interface2::class);
-$res[] = ClassType::from(Abc\Interface3::class);
-$res[] = ClassType::from(Abc\Interface4::class);
+$res[] = InterfaceType::from(Abc\Interface1::class);
+$res[] = InterfaceType::from(Abc\Interface2::class);
+$res[] = InterfaceType::from(Abc\Interface3::class);
+$res[] = InterfaceType::from(Abc\Interface4::class);
 $res[] = ClassType::from(Abc\Class1::class);
 $res[] = ClassType::from(new Abc\Class2);
 $obj = new Abc\Class3;

--- a/tests/PhpGenerator/ClassType.from.trait.phpt
+++ b/tests/PhpGenerator/ClassType.from.trait.phpt
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\ClassLike;
 
 require __DIR__ . '/../bootstrap.php';
 require __DIR__ . '/fixtures/traits.php';
@@ -19,11 +19,11 @@ $classes = [
 	Class5::class,
 ];
 
-$res = array_map(fn($class) => ClassType::from($class), $classes);
+$res = array_map(fn($class) => ClassLike::from($class), $classes);
 
 sameFile(__DIR__ . '/expected/ClassType.from.trait-use.expect', implode("\n", $res));
 
 
-$res = array_map(fn($class) => ClassType::from($class, withBodies: true), $classes);
+$res = array_map(fn($class) => ClassLike::from($class, withBodies: true), $classes);
 
 sameFile(__DIR__ . '/expected/ClassType.from.trait-use.bodies.expect', implode("\n", $res));


### PR DESCRIPTION
- new feature
- BC break? yes
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

When reading a `ClassType` from a FQCN or a file, the result can be anything from the 4 subclasses. When we know the type of the object that is parsed, having a more strict return type has additional benefits:
- Assert the object type, and throw a PHP error if the type is not the expected one.
- Helps static analysis to identifies the methods that can be used on the object (IDE completion, error detection)

Usage:
If the type is unknown, use `ClassLike::from($class)`.
Otherwise, when the expected type is known, use the more specific `ClassType::from($fqcn)`, `TraitType::from($fqcn)`, `InterfaceType::from($fqcn)`, or `EnumType::from($fqcn)`.

This is a breaking change for users that call `ClassType::from($fqcn)` on something that is not a class name.