### PR TITLE
PhpGenerator: fixed trailing comma in method parameters

### DIFF
--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -331,9 +331,10 @@ class Printer
 	{
 		$params = $function->getParameters();
 		$res = '';
+        $lastParam = end($params);
 
 		foreach ($params as $param) {
-			$variadic = $function->isVariadic() && $param === end($params);
+            $variadic = $function->isVariadic() && $param === $lastParam;
 			$attrs = $this->printAttributes($param->getAttributes(), inline: true);
 			$res .=
 				$this->printDocComment($param)
@@ -346,12 +347,13 @@ class Printer
 				. ($variadic ? '...' : '')
 				. '$' . $param->getName()
 				. ($param->hasDefaultValue() && !$variadic ? ' = ' . $this->dump($param->getDefaultValue()) : '')
-				. ($multiline ? ",\n" : ', ');
+                . ($param !== $lastParam ? ',' : '')
+				. ($multiline ? "\n" : ' ');
 		}
 
 		return $multiline
 			? "(\n" . $this->indent($res) . ')'
-			: '(' . substr($res, 0, -2) . ')';
+			: '(' . rtrim($res) . ')';
 	}
 
 

--- a/tests/PhpGenerator/Closure.long.phpt
+++ b/tests/PhpGenerator/Closure.long.phpt
@@ -33,7 +33,7 @@ same(
 			$abcdq,
 			$abcdr,
 			$abcds,
-			$abcdt,
+			$abcdt
 		) use (
 			$abcde,
 			$abcdf,

--- a/tests/PhpGenerator/Method.longParams.phpt
+++ b/tests/PhpGenerator/Method.longParams.phpt
@@ -27,7 +27,7 @@ same(
 			string $i,
 			string $j,
 			string $k,
-			string $l,
+			string $l
 		) {
 			return null;
 		}

--- a/tests/PhpGenerator/Printer.function.phpt
+++ b/tests/PhpGenerator/Printer.function.phpt
@@ -33,7 +33,7 @@ $function->addParameter('foo')
 Assert::match(<<<'XX'
 	function multi(
 		#[Foo]
-		$foo,
+		$foo
 	) {
 	}
 	XX, $printer->printFunction($function));
@@ -48,7 +48,7 @@ $function
 Assert::match(<<<'XX'
 	function multiType(
 		#[Foo]
-		$foo,
+		$foo
 	): array
 	{
 	}
@@ -121,7 +121,7 @@ $param->addAttribute('Foo', [1, 2, 3]);
 Assert::match(<<<'XX'
 	function func(
 		#[Foo(1, 2, 3)]
-		$foo,
+		$foo
 	) {
 	}
 	XX, $printer->printFunction($function));
@@ -136,7 +136,7 @@ $param->addAttribute('Bar');
 Assert::match(<<<'XX'
 	function func(
 		#[Foo(1, 2, 3), Bar]
-		$foo,
+		$foo
 	) {
 	}
 	XX, $printer->printFunction($function));
@@ -157,7 +157,7 @@ Assert::match(<<<'XX'
 			'a',
 			'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
 		)]
-		$foo,
+		$foo
 	) {
 	}
 	XX, $printer->printFunction($function));
@@ -176,7 +176,7 @@ Assert::match(<<<'XX'
 			'a',
 			'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
 		)]
-		$foo,
+		$foo
 	) {
 	}
 	XX, $printer->printFunction($function));

--- a/tests/PhpGenerator/Printer.single.parameter.phpt
+++ b/tests/PhpGenerator/Printer.single.parameter.phpt
@@ -65,7 +65,7 @@ $method
 
 Assert::match(<<<'XX'
 	public function singleMethod(
-		public $looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
+		public $looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
 	): array
 	{
 	}
@@ -81,7 +81,7 @@ Assert::match(<<<'XX'
 	function singleMethod(
 		#[Foo('
 		')]
-		$foo,
+		$foo
 	) {
 	}
 	XX, $printer->printMethod($method));

--- a/tests/PhpGenerator/expected/ClassType.attributes.expect
+++ b/tests/PhpGenerator/expected/ClassType.attributes.expect
@@ -23,7 +23,7 @@ class Example
 	public function getHandle(
 		/** comment */
 		#[ExampleAttribute, WithArguments(0)]
-		$mode,
+		$mode
 	) {
 	}
 }

--- a/tests/PhpGenerator/expected/ClassType.expect
+++ b/tests/PhpGenerator/expected/ClassType.expect
@@ -52,6 +52,6 @@ abstract class Example extends ParentClass implements IExample, IOne
 		/** comment */
 		$item,
 		array|null &$res = null,
-		stdClass|string|null $bar = null,
+		stdClass|string|null $bar = null
 	);
 }

--- a/tests/PhpGenerator/expected/ClassType.from.81.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.81.expect
@@ -28,7 +28,7 @@ class Class12
 
 
 	public function __construct(
-		public readonly string $foo,
+		public readonly string $foo
 	) {
 	}
 }

--- a/tests/PhpGenerator/expected/ClassType.from.82.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.82.expect
@@ -4,7 +4,7 @@ readonly class Class13
 
 
 	public function __construct(
-		public bool $bar = true,
+		public bool $bar = true
 	) {
 	}
 

--- a/tests/PhpGenerator/expected/ClassType.from.expect
+++ b/tests/PhpGenerator/expected/ClassType.from.expect
@@ -112,7 +112,7 @@ class Class8
 	public function __construct(
 		public $a,
 		public string|int $b = 10,
-		$c = null,
+		$c = null
 	) {
 	}
 }
@@ -140,7 +140,7 @@ class Class9
 	#[ExampleAttribute]
 	public function getHandle(
 		#[WithArguments(123)]
-		$mode,
+		$mode
 	) {
 	}
 }

--- a/tests/PhpGenerator/expected/ClassType.promotion.expect
+++ b/tests/PhpGenerator/expected/ClassType.promotion.expect
@@ -6,7 +6,7 @@ class Example
 		/** promo */
 		#[Example]
 		private string $c,
-		public readonly Draft $d = new Draft(10),
+		public readonly Draft $d = new Draft(10)
 	) {
 	}
 }

--- a/tests/PhpGenerator/expected/Extractor.classes.81.expect
+++ b/tests/PhpGenerator/expected/Extractor.classes.81.expect
@@ -34,7 +34,7 @@ class Class12
 
 
 	public function __construct(
-		private readonly string $foo,
+		private readonly string $foo
 	) {
 		$this->bar = "foobar";
 	}

--- a/tests/PhpGenerator/expected/Extractor.classes.82.expect
+++ b/tests/PhpGenerator/expected/Extractor.classes.82.expect
@@ -10,7 +10,7 @@ readonly class Class13
 
 
 	public function __construct(
-		private bool $bar = true,
+		private bool $bar = true
 	) {
 	}
 

--- a/tests/PhpGenerator/expected/Extractor.classes.expect
+++ b/tests/PhpGenerator/expected/Extractor.classes.expect
@@ -67,7 +67,7 @@ class Class2 extends Class1 implements Interface2
 		Unknown $c,
 		\Xyz\Unknown $d,
 		?callable $e,
-		$f,
+		$f
 	) {
 	}
 
@@ -129,7 +129,7 @@ class Class8
 	public function __construct(
 		public $a,
 		private int|string $b = 10,
-		$c = null,
+		$c = null
 	) {
 	}
 }
@@ -157,7 +157,7 @@ class Class9
 	#[ExampleAttribute]
 	public function getHandle(
 		#[WithArguments(123)]
-		$mode,
+		$mode
 	) {
 	}
 }

--- a/tests/PhpGenerator/expected/PhpNamespace.expect
+++ b/tests/PhpGenerator/expected/PhpNamespace.expect
@@ -18,7 +18,7 @@ class A implements A, C
 		parent $c,
 		array $d,
 		?callable $e,
-		C|string $f,
+		C|string $f
 	): static|A
 	{
 	}

--- a/tests/PhpGenerator/expected/Printer.class-alt.expect
+++ b/tests/PhpGenerator/expected/Printer.class-alt.expect
@@ -65,7 +65,7 @@ final class Example extends ParentClass implements IExample
 
 	public function multi(
 		#[Foo]
-		$foo,
+		$foo
 	) {
 	}
 
@@ -73,7 +73,7 @@ final class Example extends ParentClass implements IExample
 
 	public function multiType(
 		#[Foo]
-		$foo,
+		$foo
 	): array {
 	}
 }

--- a/tests/PhpGenerator/expected/Printer.class.expect
+++ b/tests/PhpGenerator/expected/Printer.class.expect
@@ -63,14 +63,14 @@ final class Example extends ParentClass implements IExample
 
 	public function multi(
 		#[Foo]
-		$foo,
+		$foo
 	) {
 	}
 
 
 	public function multiType(
 		#[Foo]
-		$foo,
+		$foo
 	): array
 	{
 	}

--- a/tests/PhpGenerator/expected/PsrPrinter.class.expect
+++ b/tests/PhpGenerator/expected/PsrPrinter.class.expect
@@ -56,7 +56,7 @@ final class Example extends ParentClass implements IExample
 
     public function braces1(
         #[attr]
-        $var,
+        $var
     ): stdClass {
     }
 }


### PR DESCRIPTION
Modified the formatParameters method to remove the trailing comma after the last parameter in both multiline and single-line formats.

- bug fix
- no BC break
