### PR TITLE
Property hooks (php 8.4)

### DIFF
--- a/src/PhpGenerator/InterfaceType.php
+++ b/src/PhpGenerator/InterfaceType.php
@@ -19,6 +19,7 @@ final class InterfaceType extends ClassLike
 {
 	use Traits\ConstantsAware;
 	use Traits\MethodsAware;
+	use Traits\PropertiesAware;
 
 	/** @var string[] */
 	private array $extends = [];
@@ -54,12 +55,13 @@ final class InterfaceType extends ClassLike
 	/**
 	 * Adds a member. If it already exists, throws an exception or overwrites it if $overwrite is true.
 	 */
-	public function addMember(Method|Constant $member, bool $overwrite = false): static
+	public function addMember(Method|Constant|Property $member, bool $overwrite = false): static
 	{
 		$name = $member->getName();
 		[$type, $n] = match (true) {
 			$member instanceof Constant => ['consts', $name],
 			$member instanceof Method => ['methods', strtolower($name)],
+			$member instanceof Property => ['properties', $name],
 		};
 		if (!$overwrite && isset($this->$type[$n])) {
 			throw new Nette\InvalidStateException("Cannot add member '$name', because it already exists.");
@@ -75,5 +77,6 @@ final class InterfaceType extends ClassLike
 		$clone = fn($item) => clone $item;
 		$this->consts = array_map($clone, $this->consts);
 		$this->methods = array_map($clone, $this->methods);
+		$this->properties = array_map($clone, $this->properties);
 	}
 }

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -46,8 +46,7 @@ class Printer
 			. $function->getName();
 		$returnType = $this->printReturnType($function);
 		$params = $this->printParameters($function, strlen($line) + strlen($returnType) + 2); // 2 = parentheses
-		$body = Helpers::simplifyTaggedNames($function->getBody(), $this->namespace);
-		$body = ltrim(rtrim(Strings::normalize($body)) . "\n");
+		$body = $this->printFunctionBody($function) . "\n";
 		$braceOnNextLine = $this->isBraceOnNextLine(str_contains($params, "\n"), (bool) $returnType);
 
 		return $this->printDocComment($function)
@@ -71,8 +70,7 @@ class Printer
 		$useStr = strlen($tmp = implode(', ', $uses)) > $this->wrapLength && count($uses) > 1
 			? "\n" . $this->indentation . implode(",\n" . $this->indentation, $uses) . ",\n"
 			: $tmp;
-		$body = Helpers::simplifyTaggedNames($closure->getBody(), $this->namespace);
-		$body = ltrim(rtrim(Strings::normalize($body)) . "\n");
+		$body = $this->printFunctionBody($closure) . "\n";
 
 		return $this->printAttributes($closure->getAttributes(), inline: true)
 			. 'function '
@@ -93,14 +91,14 @@ class Printer
 			}
 		}
 
-		$body = Helpers::simplifyTaggedNames($closure->getBody(), $this->namespace);
+		$body = $this->printFunctionBody($closure);
 
 		return $this->printAttributes($closure->getAttributes())
 			. 'fn'
 			. ($closure->getReturnReference() ? '&' : '')
 			. $this->printParameters($closure)
 			. $this->printReturnType($closure)
-			. ' => ' . trim(Strings::normalize($body)) . ';';
+			. ' => ' . $body . ';';
 	}
 
 
@@ -117,8 +115,7 @@ class Printer
 			. $method->getName();
 		$returnType = $this->printReturnType($method);
 		$params = $this->printParameters($method, strlen($line) + strlen($returnType) + strlen($this->indentation) + 2);
-		$body = Helpers::simplifyTaggedNames($method->getBody(), $this->namespace);
-		$body = ltrim(rtrim(Strings::normalize($body)) . "\n");
+		$body = $this->printFunctionBody($method) . "\n";
 		$braceOnNextLine = $this->isBraceOnNextLine(str_contains($params, "\n"), (bool) $returnType);
 
 		return $this->printDocComment($method)
@@ -131,6 +128,12 @@ class Printer
 				: ($braceOnNextLine ? "\n" : ' ') . "{\n" . $this->indent($body) . "}\n");
 	}
 
+    protected function printFunctionBody(Closure|GlobalFunction|Method $function): string
+    {
+        return trim(Strings::normalize(
+            Helpers::simplifyTaggedNames($function->getBody(), $this->namespace)
+        ));
+    }
 
 	public function printClass(
 		ClassType|InterfaceType|TraitType|EnumType $class,
@@ -193,9 +196,11 @@ class Printer
 		}
 
 		$properties = [];
-		if ($class instanceof ClassType || $class instanceof TraitType) {
+		if ($class instanceof ClassType || $class instanceof TraitType || $class instanceof InterfaceType) {
 			foreach ($class->getProperties() as $property) {
-				$properties[] = $this->printProperty($property, $readOnlyClass);
+                if (!$class instanceof InterfaceType || ($property->hasGetHook() || $property->hasSetHook())) {
+                    $properties[] = $this->printProperty($property, $readOnlyClass, $class->isInterface());
+                }
 			}
 		}
 
@@ -370,7 +375,7 @@ class Printer
 	}
 
 
-	private function printProperty(Property $property, bool $readOnlyClass = false): string
+	private function printProperty(Property $property, bool $readOnlyClass = false, bool $isInterface = false): string
 	{
 		$property->validate();
 		$type = $property->getType();
@@ -381,13 +386,18 @@ class Printer
 			. ltrim($this->printType($type, $property->isNullable()) . ' ')
 			. '$' . $property->getName());
 
+		$hooks = $this->printHooks($property, $isInterface);
+
+        $defaultValue = $isInterface || ($property->getValue() === null && !$property->isInitialized())
+            ? ''
+            : ' = ' . $this->dump($property->getValue(), strlen($def) + 3); // 3 = ' = '
+
 		return $this->printDocComment($property)
 			. $this->printAttributes($property->getAttributes())
 			. $def
-			. ($property->getValue() === null && !$property->isInitialized()
-				? ''
-				: ' = ' . $this->dump($property->getValue(), strlen($def) + 3)) // 3 = ' = '
-			. ";\n";
+            . $defaultValue
+			. ($hooks ?? ';')
+			. "\n";
 	}
 
 
@@ -484,4 +494,31 @@ class Printer
 	{
 		return $this->bracesOnNextLine && (!$multiLine || $hasReturnType);
 	}
+
+    private function printHooks(Property $property, bool $isInterface = false): ?string
+    {
+        $getHook = $property->getGetHook();
+        $setHook = $property->getSetHook();
+
+        if ($getHook === null && $setHook === null) {
+            return null;
+        }
+
+        $out = " {" . ($isInterface ? ' ' : "\n");
+        
+        if ($getHook !== null) {
+            $out .= $isInterface ? "get; " : $this->indent(
+                "get {\n" . $this->indent($this->printFunctionBody($getHook)) . "\n}\n"
+            );
+        }
+
+        if ($setHook !== null) {
+            $params = $this->printParameters($setHook);
+            $out .= $isInterface ? "set; " : $this->indent(
+                'set ' . $params . ' {' . "\n" . $this->indent($this->printFunctionBody($setHook)) . "\n}\n"
+            );
+        }
+
+        return $out . '}';
+    }
 }

--- a/src/PhpGenerator/Property.php
+++ b/src/PhpGenerator/Property.php
@@ -29,6 +29,8 @@ final class Property
 	private bool $nullable = false;
 	private bool $initialized = false;
 	private bool $readOnly = false;
+	private ?Closure $getHook = null;
+	private ?Closure $setHook = null;
 
 
 	public function setValue(mixed $val): static
@@ -112,6 +114,37 @@ final class Property
 		return $this->readOnly;
 	}
 
+	public function setGetHook(?Closure $hook = null): static
+	{
+		$this->getHook = $hook;
+		return $this;
+	}
+
+	public function getGetHook(): ?Closure
+	{
+		return $this->getHook;
+	}
+
+	public function hasGetHook(): bool
+	{
+		return $this->getHook !== null;
+	}
+
+	public function setSetHook(?Closure $hook = null): static
+	{
+		$this->setHook = $hook;
+		return $this;
+	}
+
+	public function getSetHook(): ?Closure
+	{
+		return $this->setHook;
+	}
+
+	public function hasSetHook(): bool
+	{
+		return $this->setHook !== null;
+	}
 
 	/** @throws Nette\InvalidStateException */
 	public function validate(): void

--- a/tests/PhpGenerator/Property.hooks.classes.phpt
+++ b/tests/PhpGenerator/Property.hooks.classes.phpt
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Test: Nette\PhpGenerator - PHP 8.4 property hooks for classes
+ */
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\InterfaceType;
+use Nette\PhpGenerator\PhpFile;
+use Nette\PhpGenerator\PsrPrinter;
+use Tester\Assert;
+use Nette\PhpGenerator\Closure;
+
+require __DIR__ . '/../bootstrap.php';
+
+$file = new PhpFile;
+$file->setStrictTypes();
+
+$class = new ClassType('Locale');
+
+$class->addProperty('languageCode')
+    ->setType('string')
+    ->setPublic();
+
+$countryCodeSetHookClosure = (new Closure)
+    ->setBody('$this->countryCode = strtoupper($countryCode);');
+
+$countryCodeSetHookClosure->addParameter('countryCode')->setType('string');
+
+$class->addProperty('countryCode')
+    ->setType('string')
+    ->setValue('AA')
+    ->setPublic()
+    ->setSetHook($countryCodeSetHookClosure);
+
+$combinedCodeGetHookClosure = (new Closure)
+    ->setBody('return \sprintf("%s_%s", $this->languageCode, $this->countryCode);');
+
+$combinedCodeSetHookClosure = (new Closure)
+    ->setBody('[$this->languageCode, $this->countryCode] = explode(\'_\', $value, 2);');
+
+$combinedCodeSetHookClosure->addParameter('value')->setType('string');
+
+$class->addProperty('combinedCode')
+    ->setType('string')
+    ->setPublic()
+    ->setGetHook($combinedCodeGetHookClosure)
+    ->setSetHook($combinedCodeSetHookClosure);
+
+$expected = <<<'PHP'
+class Locale
+{
+    public string $languageCode;
+
+    public string $countryCode = 'AA' {
+        set (string $countryCode) {
+            $this->countryCode = strtoupper($countryCode);
+        }
+    }
+
+    public string $combinedCode {
+        get {
+            return \sprintf("%s_%s", $this->languageCode, $this->countryCode);
+        }
+        set (string $value) {
+            [$this->languageCode, $this->countryCode] = explode('_', $value, 2);
+        }
+    }
+}
+PHP;
+
+dump((new PsrPrinter)->printClass($class));
+
+same(rtrim($expected), rtrim((new PsrPrinter)->printClass($class)));

--- a/tests/PhpGenerator/Property.hooks.interfaces.phpt
+++ b/tests/PhpGenerator/Property.hooks.interfaces.phpt
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Test: Nette\PhpGenerator - PHP 8.4 property hooks for interfaces
+ */
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\InterfaceType;
+use Nette\PhpGenerator\PhpFile;
+use Nette\PhpGenerator\PsrPrinter;
+use Nette\PhpGenerator\Type;
+use Tester\Assert;
+use Nette\PhpGenerator\Closure;
+
+require __DIR__ . '/../bootstrap.php';
+
+$file = new PhpFile;
+$file->setStrictTypes();
+
+$namespace = $file->addNamespace('Abc');
+
+$interface = new InterfaceType('HasAuthor');
+
+// This will not be printed because it does not have any hooks
+$interface->addProperty('isVisible')
+    ->setType(Type::Bool)
+    ->setPublic();
+
+$interface->addProperty('score')
+    ->setType(Type::Int)
+    ->setPublic()
+    ->setGetHook(new Closure());
+
+$interface->addProperty('author')
+    ->setType('Author')
+    ->setPublic()
+    ->setGetHook(new Closure())
+    ->setSetHook(new Closure());
+
+$expected = <<<'PHP'
+interface HasAuthor
+{
+    public int $score { get; }
+    public Author $author { get; set; }
+}
+PHP;
+
+same(rtrim($expected), rtrim((new PsrPrinter)->printClass($interface)));


### PR DESCRIPTION
- new feature - add support for properties hooks (for classes and interfaces)
- no BC break
- no doc PR

This adds an ability to define get and set [property hooks](https://www.php.net/manual/en/migration84.new-features.php#migration84.new-features.core.property-hooks) to classes.

Also now it's possible to add properties with hooks to interfaces, this is also implemented.

But I'm not sure about the fullness of this implementation, because it's also possible to define hooks as arrow functions, but I did not came up with the idea how to implement it.

I'm open to ideas!