### PR TITLE
Extract property hook bodies properly

### DIFF
--- a/src/PhpGenerator/Extractor.php
+++ b/src/PhpGenerator/Extractor.php
@@ -79,27 +79,27 @@ final class Extractor
 	}
 
 
-    /** @return array<string, array<string, string>> */
-    public function extractPropertyHookBodies(string $className): array
-    {
-    	$nodeFinder = new NodeFinder();
-    	$classNode = $nodeFinder->findFirst(
-    		$this->statements,
-    		fn(Node $node) => $node instanceof Node\Stmt\ClassLike && $node->namespacedName->toString() === $className,
-    	);
+	/** @return array<string, array<string, string>> */
+	public function extractPropertyHookBodies(string $className): array
+	{
+		$nodeFinder = new NodeFinder();
+		$classNode = $nodeFinder->findFirst(
+			$this->statements,
+			fn(Node $node) => $node instanceof Node\Stmt\ClassLike && $node->namespacedName->toString() === $className,
+		);
 
-    	$res = [];
-    	foreach ($nodeFinder->findInstanceOf($classNode, Node\Stmt\Property::class) as $propertyNode) {
-    		foreach ($propertyNode->props as $propNode) {
-    			$propName = $propNode->name->toString();
-    			foreach ($propertyNode->hooks as $hookNode) {
-    				$hookType = $hookNode->name->toString();
-    				$res[$propName][$hookType] = $this->getReformattedContents([$hookNode->body], 1);
-    			}
-    		}
-    	}
-    	return $res;
-    }
+		$res = [];
+		foreach ($nodeFinder->findInstanceOf($classNode, Node\Stmt\Property::class) as $propertyNode) {
+			foreach ($propertyNode->props as $propNode) {
+				$propName = $propNode->name->toString();
+				foreach ($propertyNode->hooks as $hookNode) {
+					$hookType = $hookNode->name->toString();
+					$res[$propName][$hookType] = $this->getReformattedContents([$hookNode->body], 1);
+				}
+			}
+		}
+		return $res;
+	}
 
 
 	public function extractFunctionBody(string $name): ?string

--- a/src/PhpGenerator/Extractor.php
+++ b/src/PhpGenerator/Extractor.php
@@ -79,6 +79,29 @@ final class Extractor
 	}
 
 
+    /** @return array<string, array<string, string>> */
+    public function extractPropertyHookBodies(string $className): array
+    {
+    	$nodeFinder = new NodeFinder();
+    	$classNode = $nodeFinder->findFirst(
+    		$this->statements,
+    		fn(Node $node) => $node instanceof Node\Stmt\ClassLike && $node->namespacedName->toString() === $className,
+    	);
+
+    	$res = [];
+    	foreach ($nodeFinder->findInstanceOf($classNode, Node\Stmt\Property::class) as $propertyNode) {
+    		foreach ($propertyNode->props as $propNode) {
+    			$propName = $propNode->name->toString();
+    			foreach ($propertyNode->hooks as $hookNode) {
+    				$hookType = $hookNode->name->toString();
+    				$res[$propName][$hookType] = $this->getReformattedContents([$hookNode->body], 1);
+    			}
+    		}
+    	}
+    	return $res;
+    }
+
+
 	public function extractFunctionBody(string $name): ?string
 	{
 		$functionNode = (new NodeFinder)->findFirst(

--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -124,12 +124,12 @@ final class Factory
 			$resolutions = [];
 		}
 
-        if ($withBodies) {
-            $hookBodies = $this->getExtractor($declaringClass->getFileName())->extractPropertyHookBodies($declaringClass->name);
-            foreach ($class->getProperties() as $property) {
-            	foreach ($hookBodies[$property->getName()] ?? [] as $hookType => $body) {
-            		$property->getHook($hookType)?->setBody($body, short: true);
-            	}
+		if ($withBodies) {
+			$hookBodies = $this->getExtractor($declaringClass->getFileName())->extractPropertyHookBodies($declaringClass->name);
+			foreach ($class->getProperties() as $property) {
+				foreach ($hookBodies[$property->getName()] ?? [] as $hookType => $body) {
+					$property->getHook($hookType)?->setBody($body, short: true);
+				}
 			}
 		}
 

--- a/src/PhpGenerator/Factory.php
+++ b/src/PhpGenerator/Factory.php
@@ -124,6 +124,15 @@ final class Factory
 			$resolutions = [];
 		}
 
+        if ($withBodies) {
+            $hookBodies = $this->getExtractor($declaringClass->getFileName())->extractPropertyHookBodies($declaringClass->name);
+            foreach ($class->getProperties() as $property) {
+            	foreach ($hookBodies[$property->getName()] ?? [] as $hookType => $body) {
+            		$property->getHook($hookType)?->setBody($body, short: true);
+            	}
+			}
+		}
+
 		$consts = $cases = [];
 		foreach ($from->getReflectionConstants() as $const) {
 			if ($class->isEnum() && $from->hasCase($const->name)) {


### PR DESCRIPTION
This PR aims to fix this issue: https://github.com/tempestphp/tempest-framework/issues/866

Reproduction:
```php
$printer = new Printer();
$from = ClassType::from(Foo::class, withBodies: true);
$fromCode = ClassType::fromCode(file_get_contents(__DIR__ . '/Foo.php'));
echo $printer->printClass($from) . PHP_EOL;
echo $printer->printClass($fromCode);

// Foo.php
class Foo
{
    public $bar {
        get => 'test string';
    }
}
```

Output before:
```php
class Foo
{
	public $bar {
		get {
		}
	}
}

class Foo
{
	public $bar {
		get => 'test string';
	}
}
```

Output after:
```php
class Foo
{
	public $bar {
		get => 'test string';
	}
}

class Foo
{
	public $bar {
		get => 'test string';
	}
}
```