### PR TITLE
feat: add wrapping of global function with existing check

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -297,6 +297,7 @@ $function = new Nette\PhpGenerator\GlobalFunction('foo');
 $function->setBody('return $a + $b;');
 $function->addParameter('a');
 $function->addParameter('b');
+$function->wrapInExistingCheck();
 echo $function;
 
 // or use the PsrPrinter for output compliant with PSR-2 / PSR-12 / PER
@@ -306,9 +307,12 @@ echo $function;
 The result is:
 
 ```php
-function foo($a, $b)
+if (! function_exists('foo'))
 {
-	return $a + $b;
+    function foo($a, $b)
+    {
+        return $a + $b;
+    }
 }
 ```
 

--- a/src/PhpGenerator/GlobalFunction.php
+++ b/src/PhpGenerator/GlobalFunction.php
@@ -22,6 +22,8 @@ final class GlobalFunction
 	use Traits\CommentAware;
 	use Traits\AttributeAware;
 
+	private bool $wrapInExistingCheck = false;
+
 	public static function from(string|\Closure $function, bool $withBody = false): self
 	{
 		return (new Factory)->fromFunctionReflection(Nette\Utils\Callback::toReflection($function), $withBody);
@@ -37,5 +39,17 @@ final class GlobalFunction
 	public function __clone(): void
 	{
 		$this->parameters = array_map(fn($param) => clone $param, $this->parameters);
+	}
+
+
+	public function wrapInExistingCheck(bool $wrap = true): self
+	{
+		$this->wrapInExistingCheck = $wrap;
+		return $this;
+	}
+
+	public function getWrapInExistingCheck(): bool
+	{
+		return $this->wrapInExistingCheck;
 	}
 }

--- a/src/PhpGenerator/Printer.php
+++ b/src/PhpGenerator/Printer.php
@@ -49,13 +49,17 @@ class Printer
 		$body = $this->printFunctionBody($function);
 		$braceOnNextLine = $this->isBraceOnNextLine(str_contains($params, "\n"), (bool) $returnType);
 
-		return $this->printDocComment($function)
+		$functionPrint = $this->printDocComment($function)
 			. $this->printAttributes($function->getAttributes())
 			. $line
 			. $params
 			. $returnType
 			. ($braceOnNextLine ? "\n" : ' ')
 			. "{\n" . $this->indent($body) . "}\n";
+
+		$wrapper = "if (! function_exists('{$function->getName()}'))\n{\n{$this->indent($functionPrint)}}\n";
+
+		return $function->getWrapInExistingCheck() ? $wrapper : $functionPrint;
 	}
 
 

--- a/tests/PhpGenerator/GlobalFunction.wrapped.phpt
+++ b/tests/PhpGenerator/GlobalFunction.wrapped.phpt
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\PhpGenerator\GlobalFunction;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$function = new GlobalFunction('test');
+$function->setBody('return $a + $b;');
+$function->addAttribute('ExampleAttribute');
+$function->addComment('My Function');
+$function->wrapInExistingCheck();
+
+same(
+	<<<'XX'
+		if (! function_exists('test'))
+		{
+			/**
+			 * My Function
+			 */
+			#[ExampleAttribute]
+			function test()
+			{
+				return $a + $b;
+			}
+		}
+
+		XX,
+	(string) $function,
+);


### PR DESCRIPTION
- bug fix / new feature?   <!-- #issue numbers, if any -->
- feature
- BC break? yes/no
- no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->
- can be done if merged

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
I'm generating a lot of helper methods recently, but I have the need to wrap them into a function exist check. It is kinda duplicated if done manually, so I want it to be part of the generation itself. The code style may differ a lot from the code style of the project, feel free to adjust it